### PR TITLE
Use a better-supported Unicode arrow character in reports

### DIFF
--- a/src/Report.hs
+++ b/src/Report.hs
@@ -44,5 +44,5 @@ getReportSuggestion = \case
             Replace -> color Yellow "Replace"
         <> " "
         <> color Magenta (display extraDep)
-        <> "\n        ⮡ "
+        <> "\n        ↳ "
         <> sDetails


### PR DESCRIPTION
The arrow currently being used:

* U+2BA1 DOWNWARDS TRIANGLE-HEADED ARROW WITH LONG TIP RIGHTWARDS (⮡)

appears in very few common fonts whereas this one:

* U+21B3 DOWNWARDS ARROW WITH TIP RIGHTWARDS (↳)

appears in a lot of them. I think the replacement is almost as good visually, and is much less likely to appear as a box or generic replacement character on typical systems.