### PR TITLE
Support github short-hand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/stack-lint-extra-deps/compare/v1.1.0.1...main)
+## [_Unreleased_](https://github.com/freckle/stack-lint-extra-deps/compare/v1.1.0.2...main)
 
-None
+## [v1.1.0.2](https://github.com/freckle/stack-lint-extra-deps/compare/v1.1.0.1...v1.1.0.2)
+
+- Support `github` short-hand
 
 ## [v1.1.0.1](https://github.com/freckle/stack-lint-extra-deps/compare/v1.1.0.0...v1.1.0.1)
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,9 +1,11 @@
 name: stack-lint-extra-deps
-version: 1.1.0.1
+version: 1.1.0.2
 
-extra-source-files:
+extra-doc-files:
   - README.md
   - CHANGELOG.md
+
+extra-source-files:
   - test/examples/lts-18.18.yaml
 
 default-extensions:

--- a/src/GitExtraDep.hs
+++ b/src/GitExtraDep.hs
@@ -18,8 +18,10 @@ data GitExtraDep = GitExtraDep
   deriving stock Show
 
 instance FromJSON GitExtraDep where
-  parseJSON = withObject "GitExtraDep"
-    $ \o -> GitExtraDep <$> o .: "git" <*> o .: "commit"
+  parseJSON = withObject "GitExtraDep" $ \o -> do
+    gh <- o .:? "github"
+    repo <- maybe (o .: "git") (pure . Repository . (ghBase <>)) gh
+    GitExtraDep repo <$> o .: "commit"
 
 instance Display GitExtraDep where
   display GitExtraDep {..} = display gedRepository <> "@" <> display gedCommit
@@ -30,7 +32,7 @@ newtype Repository = Repository
     deriving newtype (Show, Display, FromJSON)
 
 repositoryBase :: Repository -> Text
-repositoryBase = T.dropPrefix "https://github.com/" . unRepository
+repositoryBase = T.dropPrefix ghBase . unRepository
 
 repositoryBaseName :: Repository -> Text
 repositoryBaseName = T.drop 1 . T.dropWhile (/= '/') . repositoryBase
@@ -42,3 +44,6 @@ newtype CommitSHA = CommitSHA
 
 instance Display CommitSHA where
   display (CommitSHA x) = display $ T.take 7 x
+
+ghBase :: Text
+ghBase = "https://github.com/"

--- a/stack-lint-extra-deps.cabal
+++ b/stack-lint-extra-deps.cabal
@@ -1,18 +1,19 @@
-cabal-version: 1.12
+cabal-version: 1.18
 
 -- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 
 name:           stack-lint-extra-deps
-version:        1.1.0.1
+version:        1.1.0.2
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 extra-source-files:
+    test/examples/lts-18.18.yaml
+extra-doc-files:
     README.md
     CHANGELOG.md
-    test/examples/lts-18.18.yaml
 
 library
   exposed-modules:

--- a/test/RunSpec.hs
+++ b/test/RunSpec.hs
@@ -16,12 +16,12 @@ import Test.Hspec.Expectations.Lifted
 spec :: Spec
 spec = do
   describe "runLsd" $ do
-    it "finds 9 Hackage suggestions in the lts-18.18 example" $ example $ do
+    it "finds 10 Hackage suggestions in the lts-18.18 example" $ example $ do
       let opts = testExampleOptions "lts-18.18" HackageChecks
       stackYaml <- loadStackYaml $ oPath opts
       withApp opts $ \app -> runRIO app $ do
         n <- runLsd opts stackYaml $ \_ _ -> pure ()
-        n `shouldBe` 9
+        n `shouldBe` 10
 
 testExampleOptions :: String -> ChecksName -> Options
 testExampleOptions name checks = Options

--- a/test/examples/lts-18.18.yaml
+++ b/test/examples/lts-18.18.yaml
@@ -14,7 +14,7 @@ packages:
   - hspec-2.8.3@sha256:43a42e23994a6c61a7adead7e8a412016680234f5a14a157f68c020871e59534,1709
   - hspec-junit-formatter-1.0.1.0@sha256:6429871263be4532a3a6d08e72da5a8e4c00e8bfbfd7fc5b8352a3643f867453,2652
 
-  # No suggestions (yet)
+  # New version available
   - network-3.1.2.5@sha256:433a5e076aaa8eb3e4158abae78fb409c6bd754e9af99bc2e87583d2bcd8404a,4888
 
   # Newer commits, version-like tag exists too

--- a/test/examples/lts-18.18.yaml
+++ b/test/examples/lts-18.18.yaml
@@ -18,7 +18,7 @@ packages:
   - network-3.1.2.5@sha256:433a5e076aaa8eb3e4158abae78fb409c6bd754e9af99bc2e87583d2bcd8404a,4888
 
   # Newer commits, version-like tag exists too
-  - git: https://github.com/freckle/yesod-routes-flow
+  - github: freckle/yesod-routes-flow
     commit: 2a9cd873880956dd9a0999b593022d3c746324e8
 
   # No suggestions (yet)


### PR DESCRIPTION
The github key is short-hand,

```yaml
github: foo/bar
# => git: https://github.com/foo/bar
```

So we should parse that too.

With the updated test file, we see it works:

```
[debug] Git details for https://github.com/freckle/yesod-routes-flow:
  Commits to HEAD: 17
  Versions by tags: 1.0 (-27 commits), 1.0.1 (-26 commits), 1.0.2 (-24 commits), 1.1 (-21 commits), 1.1.1 (-19 commits), 2.0 (-14 commits), 3.0.0.1 (15 commits), 3.0.0.2 (17 commits)
[error] Replace https://github.com/freckle/yesod-routes-flow@2a9cd87
        ↳ Same-or-newer version (3.0.0.2) exists on Hackage
[error] Replace https://github.com/freckle/yesod-routes-flow@2a9cd87
        ↳ There are newer commits (17) on the default branch
```
