### PR TITLE
Parse Options out of pragma comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/stack-lint-extra-deps/compare/v1.2.0.0...main)
+## [_Unreleased_](https://github.com/freckle/stack-lint-extra-deps/compare/v1.2.1.0...main)
+
+## [v1.2.1.0](https://github.com/freckle/stack-lint-extra-deps/compare/v1.2.0.0...v1.2.1.0)
+
+- Support parsing options from pragmas in source
 
 ## [v1.2.0.0](https://github.com/freckle/stack-lint-extra-deps/compare/v1.1.0.7...v1.2.0.0)
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,27 @@ variables][blammo-config] it supports may be used to control it, such as
 [blammo]: https:/github.com/freckle/blammo#readme
 [blammo-config]: https://github.com/freckle/blammo#configuration
 
+## Pragmas
+
+Comments prefixed by `@sled ` (e.g. "pragmas") can be added to the linted file
+and will be parsed as command-line options to change the program's behavior when
+linting that file. This is most useful for centralizing and documenting
+`--exclude` directives:
+
+```yaml
+resolver: lts-20
+extra-deps:
+  - one-dep-1.0
+
+  # We need to hold this back because...
+  # @sled --exclude another-dep
+  - another-dep-2.0
+```
+
+These comments can appear anywhere. All options besides `--path` will be
+respected. Failure to parse a directive will result in a warning logged to
+`stderr`, but otherwise be ignored.
+
 ## GitHub Action
 
 This repository is also a GitHub Action that installs and runs the tool with no

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -6,7 +6,7 @@ import SLED.Prelude
 
 import Blammo.Logging.Simple
 import SLED.App
-import SLED.Options
+import SLED.Options.Parse
 import SLED.Run
 
 main :: IO ()

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: stack-lint-extra-deps
-version: 1.2.0.0
+version: 1.2.1.0
 
 extra-doc-files:
   - README.md

--- a/package.yaml
+++ b/package.yaml
@@ -20,6 +20,7 @@ default-extensions:
   - OverloadedRecordDot
   - OverloadedStrings
   - TypeApplications
+  - DuplicateRecordFields
 
 ghc-options:
   - -fignore-optim-changes
@@ -56,6 +57,7 @@ library:
     - lens
     - optparse-applicative
     - relude
+    - semigroups
     - text
     - typed-process
     - unliftio

--- a/package.yaml
+++ b/package.yaml
@@ -58,6 +58,7 @@ library:
     - optparse-applicative
     - relude
     - semigroups
+    - shellwords
     - text
     - typed-process
     - unliftio

--- a/src/SLED/Checks.hs
+++ b/src/SLED/Checks.hs
@@ -20,6 +20,14 @@ data ChecksName
   | HackageChecks
   deriving stock (Bounded, Enum)
 
+instance Semigroup ChecksName where
+  AllChecks <> _ = AllChecks
+  _ <> AllChecks = AllChecks
+  GitChecks <> HackageChecks = AllChecks
+  HackageChecks <> GitChecks = AllChecks
+  GitChecks <> GitChecks = GitChecks
+  HackageChecks <> HackageChecks = HackageChecks
+
 checksNameOption :: Parser ChecksName
 checksNameOption =
   boundedEnumOptionWith
@@ -28,7 +36,6 @@ checksNameOption =
         long "checks"
           <> help ("Checks to run, one of: " <> list)
           <> metavar "CHECKS"
-          <> value AllChecks
     )
 
 showChecksName :: ChecksName -> String

--- a/src/SLED/Options.hs
+++ b/src/SLED/Options.hs
@@ -30,8 +30,7 @@ optionsParserInfo :: ParserInfo Options
 optionsParserInfo =
   info (optionsParser <**> helper)
     $ fullDesc
-    <> progDesc
-      "Lint Stackage (extra) Deps"
+    <> progDesc "stack lint-extra-deps (sled)"
 
 optionsParser :: Parser Options
 optionsParser =

--- a/src/SLED/Options/Parse.hs
+++ b/src/SLED/Options/Parse.hs
@@ -1,0 +1,55 @@
+module SLED.Options.Parse
+  ( Options (..)
+  , parseOptions
+  ) where
+
+import SLED.Prelude
+
+import Data.Yaml.Marked.Decode
+import Options.Applicative
+import SLED.Checks
+import SLED.Options (optionsParserInfo)
+import qualified SLED.Options as Types
+import SLED.StackYaml
+import SLED.StackageResolver
+import SLED.Suggestion.Format
+import System.FilePath.Glob
+
+data Options = Options
+  { path :: FilePath
+  , resolver :: Marked StackageResolver
+  , format :: Format
+  , excludes :: [Pattern]
+  , checks :: ChecksName
+  , noExit :: Bool
+  , filter :: Maybe Pattern
+  , stackYaml :: StackYaml
+  , stackYamlContents :: ByteString
+  }
+
+parseOptions :: IO Options
+parseOptions = do
+  envStackYaml <- lookupEnv "STACK_YAML"
+  options <- execParser optionsParserInfo
+
+  let path = fromMaybe "stack.yaml" $ getLast options.path <|> envStackYaml
+
+  bs <- readFileBS path
+  stackYaml <- liftIO $ markedItem <$> decodeThrow decodeStackYaml path bs
+
+  -- Mark an option resolver with the in-file resolver's position so that if we
+  -- do anything based on it, that's what we'll use
+  let resolver = maybe stackYaml.resolver (<$ stackYaml.resolver) $ getLast options.resolver
+
+  pure
+    Options
+      { path = path
+      , resolver = resolver
+      , format = fromMaybe defaultFormat $ getLast options.format
+      , excludes = options.excludes
+      , checks = fromMaybe AllChecks $ options.checks
+      , noExit = getAny options.noExit
+      , filter = getLast options.filter
+      , stackYaml = stackYaml
+      , stackYamlContents = bs
+      }

--- a/src/SLED/Options/Parse.hs
+++ b/src/SLED/Options/Parse.hs
@@ -10,10 +10,12 @@ import Options.Applicative
 import SLED.Checks
 import SLED.Options (optionsParserInfo)
 import qualified SLED.Options as Types
+import SLED.Options.Pragma (parsePragmaOptions)
 import SLED.StackYaml
 import SLED.StackageResolver
 import SLED.Suggestion.Format
 import System.FilePath.Glob
+import System.IO (hPutStrLn)
 
 data Options = Options
   { path :: FilePath
@@ -30,16 +32,23 @@ data Options = Options
 parseOptions :: IO Options
 parseOptions = do
   envStackYaml <- lookupEnv "STACK_YAML"
-  options <- execParser optionsParserInfo
+  cli <- execParser optionsParserInfo
 
-  let path = fromMaybe "stack.yaml" $ getLast options.path <|> envStackYaml
+  let path = fromMaybe "stack.yaml" $ getLast cli.path <|> envStackYaml
 
   bs <- readFileBS path
   stackYaml <- liftIO $ markedItem <$> decodeThrow decodeStackYaml path bs
 
-  -- Mark an option resolver with the in-file resolver's position so that if we
-  -- do anything based on it, that's what we'll use
-  let resolver = maybe stackYaml.resolver (<$ stackYaml.resolver) $ getLast options.resolver
+  let (errs, pragmas) = parsePragmaOptions bs
+
+  for_ errs $ hPutStrLn stderr . ("Warning: invalid @sled pragma:\n" <>)
+
+  let
+    options = pragmas <> cli
+
+    -- Mark an option resolver with the in-file resolver's position so that if
+    -- we do anything based on it, that's what we'll use
+    resolver = maybe stackYaml.resolver (<$ stackYaml.resolver) $ getLast options.resolver
 
   pure
     Options

--- a/src/SLED/Options/Pragma.hs
+++ b/src/SLED/Options/Pragma.hs
@@ -23,7 +23,10 @@ parsePragma =
 fromComment :: ByteString -> Maybe String
 fromComment bs =
   unpack <$> do
-    c <- T.stripPrefix "# " $ decodeUtf8With lenientDecode bs
+    c <-
+      T.stripPrefix "# "
+        . T.dropWhile isSpace
+        $ decodeUtf8With lenientDecode bs
     T.stripPrefix "@sled " $ T.dropWhile isSpace c
 
 execParser :: ParserInfo a -> [String] -> Either String a

--- a/src/SLED/Options/Pragma.hs
+++ b/src/SLED/Options/Pragma.hs
@@ -1,0 +1,36 @@
+module SLED.Options.Pragma
+  ( parsePragmaOptions
+  ) where
+
+import SLED.Prelude
+
+import qualified Data.ByteString.Char8 as BS8
+import Data.Char (isSpace)
+import qualified Data.Text as T
+import Options.Applicative (ParserInfo, ParserResult (..))
+import qualified Options.Applicative as Options
+import SLED.Options
+import qualified ShellWords
+
+parsePragmaOptions :: ByteString -> ([String], Options)
+parsePragmaOptions =
+  second fold . partitionEithers . mapMaybe parsePragma . BS8.lines
+
+parsePragma :: ByteString -> Maybe (Either String Options)
+parsePragma =
+  fmap (execParser optionsParserInfo <=< ShellWords.parse) . fromComment
+
+fromComment :: ByteString -> Maybe String
+fromComment bs =
+  unpack <$> do
+    c <- T.stripPrefix "# " $ decodeUtf8With lenientDecode bs
+    T.stripPrefix "@sled " $ T.dropWhile isSpace c
+
+execParser :: ParserInfo a -> [String] -> Either String a
+execParser p = handleParserResult . Options.execParserPure Options.defaultPrefs p
+
+handleParserResult :: ParserResult a -> Either String a
+handleParserResult = \case
+  Success a -> Right a
+  Failure x -> Left $ fst $ Options.renderFailure x "stack-lint-extra-deps"
+  CompletionInvoked {} -> Left "Unexpected completion invocation"

--- a/stack-lint-extra-deps.cabal
+++ b/stack-lint-extra-deps.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           stack-lint-extra-deps
-version:        1.2.0.0
+version:        1.2.1.0
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple

--- a/stack-lint-extra-deps.cabal
+++ b/stack-lint-extra-deps.cabal
@@ -33,6 +33,7 @@ library
       SLED.Options
       SLED.Options.BoundedEnum
       SLED.Options.Parse
+      SLED.Options.Pragma
       SLED.PackageName
       SLED.Prelude
       SLED.Run
@@ -82,6 +83,7 @@ library
     , optparse-applicative
     , relude
     , semigroups
+    , shellwords
     , text
     , typed-process
     , unliftio
@@ -151,6 +153,7 @@ test-suite hspec
       SLED.Checks.GitSpec
       SLED.Checks.HackageSpec
       SLED.HackageSpec
+      SLED.Options.PragmaSpec
       SLED.RunSpec
       SLED.StackageSpec
       SLED.Test

--- a/stack-lint-extra-deps.cabal
+++ b/stack-lint-extra-deps.cabal
@@ -32,6 +32,7 @@ library
       SLED.HackageExtraDep
       SLED.Options
       SLED.Options.BoundedEnum
+      SLED.Options.Parse
       SLED.PackageName
       SLED.Prelude
       SLED.Run
@@ -60,6 +61,7 @@ library
       OverloadedRecordDot
       OverloadedStrings
       TypeApplications
+      DuplicateRecordFields
   ghc-options: -fignore-optim-changes -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missing-import-lists -Wno-missing-kind-signatures -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module -Wno-unsafe -optP-Wno-nonportable-include-path
   build-depends:
       Blammo
@@ -79,6 +81,7 @@ library
     , lens
     , optparse-applicative
     , relude
+    , semigroups
     , text
     , typed-process
     , unliftio
@@ -105,6 +108,7 @@ executable stack-lint-extra-deps
       OverloadedRecordDot
       OverloadedStrings
       TypeApplications
+      DuplicateRecordFields
   ghc-options: -fignore-optim-changes -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missing-import-lists -Wno-missing-kind-signatures -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module -Wno-unsafe -optP-Wno-nonportable-include-path -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       Blammo
@@ -131,6 +135,7 @@ test-suite doctest
       OverloadedRecordDot
       OverloadedStrings
       TypeApplications
+      DuplicateRecordFields
   ghc-options: -fignore-optim-changes -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missing-import-lists -Wno-missing-kind-signatures -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module -Wno-unsafe -optP-Wno-nonportable-include-path
   build-depends:
       aeson
@@ -164,6 +169,7 @@ test-suite hspec
       OverloadedRecordDot
       OverloadedStrings
       TypeApplications
+      DuplicateRecordFields
   ghc-options: -fignore-optim-changes -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missing-import-lists -Wno-missing-kind-signatures -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module -Wno-unsafe -optP-Wno-nonportable-include-path
   build-depends:
       Blammo

--- a/test/SLED/Options/PragmaSpec.hs
+++ b/test/SLED/Options/PragmaSpec.hs
@@ -68,7 +68,7 @@ spec = do
             , "\n                             [-f|--format tty|gha|json] [--exclude PATTERN] "
             , "\n                             [--checks CHECKS] [-n|--no-exit] [PATTERN]"
             , "\n"
-            , "\n  Lint Stackage (extra) Deps"
+            , "\n  stack lint-extra-deps (sled)"
             ]
 
       errs `shouldBe` [expectedErr]

--- a/test/SLED/Options/PragmaSpec.hs
+++ b/test/SLED/Options/PragmaSpec.hs
@@ -1,0 +1,113 @@
+module SLED.Options.PragmaSpec
+  ( spec
+  ) where
+
+import SLED.Prelude
+
+import SLED.Options (Options (..))
+import SLED.Options.Pragma
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "parsePragmaOptions" $ do
+    it "parses simple comments" $ do
+      let
+        yaml :: ByteString
+        yaml =
+          mconcat
+            [ "# @sled --exclude foo --exclude bar\n"
+            , "resolver: x\n"
+            , "extra-deps:\n"
+            , "# This is another comment that might mention\n"
+            , "# sled at the beginning of a sentence.\n"
+            , "- foo\n"
+            , "- bar\n"
+            , "- baz\n"
+            ]
+
+      let (_errs, options) = parsePragmaOptions yaml
+
+      options.excludes `shouldBe` ["foo", "bar"]
+
+    it "parses multiple comments anywhere in the file" $ do
+      let
+        yaml :: ByteString
+        yaml =
+          mconcat
+            [ "# @sled --exclude foo --exclude baz\n"
+            , "resolver: x\n"
+            , "extra-deps:\n"
+            , "- foo\n"
+            , "- bar\n"
+            , "# @sled --exclude=\"bat\"\n"
+            , "- baz\n"
+            ]
+
+      let (_errs, options) = parsePragmaOptions yaml
+
+      options.excludes `shouldBe` ["foo", "baz", "bat"]
+
+    it "returns errors in the case of invalid options" $ do
+      let
+        yaml :: ByteString
+        yaml =
+          mconcat
+            [ "# @sled --what --no-way\n"
+            , "resolver: x\n"
+            ]
+
+      let
+        (errs, _) = parsePragmaOptions yaml
+
+        expectedErr =
+          concat
+            [ "Invalid option `--what'"
+            , "\n"
+            , "\nUsage: stack-lint-extra-deps [-p|--path PATH] [-r|--resolver RESOLVER] "
+            , "\n                             [-f|--format tty|gha|json] [--exclude PATTERN] "
+            , "\n                             [--checks CHECKS] [-n|--no-exit] [PATTERN]"
+            , "\n"
+            , "\n  Lint Stackage (extra) Deps"
+            ]
+
+      errs `shouldBe` [expectedErr]
+
+    it "returns errors in the case of invalid pragmas" $ do
+      let
+        yaml :: ByteString
+        yaml =
+          mconcat
+            [ "# @sled foo '\n"
+            , "resolver: x\n"
+            ]
+
+      let
+        (errs, _) = parsePragmaOptions yaml
+
+        expectedErr =
+          concat
+            [ "<input>:1:6:"
+            , "\n  |"
+            , "\n1 | foo '"
+            , "\n  |      ^"
+            , "\nunexpected end of input"
+            , "\nexpecting ''' or escaped'\\''"
+            , "\n"
+            ]
+
+      errs `shouldBe` [expectedErr]
+
+    it "collects all errors" $ do
+      let
+        yaml :: ByteString
+        yaml =
+          mconcat
+            [ "# @sled foo '\n"
+            , "resolver: x\n"
+            , "# @sled bar '\n"
+            ]
+
+      let (errs, _) = parsePragmaOptions yaml
+
+      errs `shouldSatisfy` (== 2) . length

--- a/test/SLED/Options/PragmaSpec.hs
+++ b/test/SLED/Options/PragmaSpec.hs
@@ -38,10 +38,10 @@ spec = do
             [ "# @sled --exclude foo --exclude baz\n"
             , "resolver: x\n"
             , "extra-deps:\n"
-            , "- foo\n"
-            , "- bar\n"
-            , "# @sled --exclude=\"bat\"\n"
-            , "- baz\n"
+            , "  - foo\n"
+            , "  - bar\n"
+            , "  # @sled --exclude=\"bat\"\n"
+            , "  - bat\n"
             ]
 
       let (_errs, options) = parsePragmaOptions yaml


### PR DESCRIPTION
The contents of the linted path are "parsed" for comments of the
following format:

```yaml
# @sled [option...]
```

Where `option...` is a valid command-line for `stack-lint-extra-deps`.

If successful, these options are merged into the CLI options (with CLI
taking precedence).

Lines without the `@sled` prefix are ignored. Lines with the prefix but
content that doesn't parse as shell-words, or does parse but are invalid
usage, are also ignored, but with warnings printed to `stderr`.

While any options can be given this way (except `--path`, which will
have no effect), the most likely use-case is lines like:

```yaml
# @sled --exclude this-dep --exclude '**/that-dep'
```

Which allow you to centralize (and document) your reasons for excluding
certain dependencies.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206594743435993