### PR TITLE
Include extra-dep in GHA title

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: freckle/stack-action@v4
+      - uses: freckle/stack-action@v5
       - uses: ./
         with:
           arguments: --format gha --path test/examples/lts-18.18.yaml --no-exit

--- a/src/SLED/Suggestion/Format/Action.hs
+++ b/src/SLED/Suggestion/Format/Action.hs
@@ -2,6 +2,7 @@
 
 module SLED.Suggestion.Format.Action
   ( formatAction
+  , formatExtraDep
   ) where
 
 import SLED.Prelude

--- a/src/SLED/Suggestion/Format/GHA.hs
+++ b/src/SLED/Suggestion/Format/GHA.hs
@@ -19,6 +19,8 @@ formatSuggestionGHA m =
   "::error "
     <> T.intercalate "," attrs
     <> "::"
+    <> formatExtraDep s.target
+    <> ": "
     <> suggestionActionDescription s.action
  where
   attrs =


### PR DESCRIPTION
On the title is visible in the build logs, and the build logs are where
you are linked to first when you get a failure, and the annotations
aren't visible there (only summary). All of this means that you see
this:

![](https://files.pbrisbin.com/screenshots/screenshot.1651846.png)

Which gives little indication what is going on. Including the extra-dep
itself should help.
