### PR TITLE
raise LTS to 22.6

### DIFF
--- a/src/SLED/ExtraDep.hs
+++ b/src/SLED/ExtraDep.hs
@@ -6,6 +6,7 @@ module SLED.ExtraDep
 
 import SLED.Prelude
 
+import Data.Either.Extra (eitherToMaybe)
 import Data.Yaml.Marked.Parse
 import Data.Yaml.Marked.Value
 import SLED.GitExtraDep
@@ -24,11 +25,10 @@ data ExtraDep
   deriving anyclass (ToJSON)
 
 decodeExtraDep :: Marked Value -> Either String (Marked ExtraDep)
-decodeExtraDep mv =
+decodeExtraDep mv = Right $ fromMaybe (Other () <$ mv) $
   asum
-    [ Git <$$> decodeGitExtraDep mv
-    , Hackage <$$> json mv
-    , pure $ Other () <$ mv
+    [ eitherToMaybe (Git <$$> decodeGitExtraDep mv)
+    , eitherToMaybe (Hackage <$$> json mv)
     ]
 
 matchPattern :: Pattern -> ExtraDep -> Bool

--- a/src/SLED/ExtraDep.hs
+++ b/src/SLED/ExtraDep.hs
@@ -6,7 +6,7 @@ module SLED.ExtraDep
 
 import SLED.Prelude
 
-import Data.Either.Extra (eitherToMaybe)
+import Control.Error.Util (hush)
 import Data.Yaml.Marked.Parse
 import Data.Yaml.Marked.Value
 import SLED.GitExtraDep
@@ -29,8 +29,8 @@ decodeExtraDep mv =
   Right
     $ fromMaybe (Other () <$ mv)
     $ asum
-      [ eitherToMaybe (Git <$$> decodeGitExtraDep mv)
-      , eitherToMaybe (Hackage <$$> json mv)
+      [ hush (Git <$$> decodeGitExtraDep mv)
+      , hush (Hackage <$$> json mv)
       ]
 
 matchPattern :: Pattern -> ExtraDep -> Bool

--- a/src/SLED/ExtraDep.hs
+++ b/src/SLED/ExtraDep.hs
@@ -25,11 +25,13 @@ data ExtraDep
   deriving anyclass (ToJSON)
 
 decodeExtraDep :: Marked Value -> Either String (Marked ExtraDep)
-decodeExtraDep mv = Right $ fromMaybe (Other () <$ mv) $
-  asum
-    [ eitherToMaybe (Git <$$> decodeGitExtraDep mv)
-    , eitherToMaybe (Hackage <$$> json mv)
-    ]
+decodeExtraDep mv =
+  Right
+    $ fromMaybe (Other () <$ mv)
+    $ asum
+      [ eitherToMaybe (Git <$$> decodeGitExtraDep mv)
+      , eitherToMaybe (Hackage <$$> json mv)
+      ]
 
 matchPattern :: Pattern -> ExtraDep -> Bool
 matchPattern p = \case

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-21.4
+resolver: lts-22.6
 extra-deps:
   - github: pbrisbin/yaml-marked
     commit: 8fe21f6cf13b78f14c0fa41c84456b5dd32bd098

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -17,7 +17,7 @@ packages:
     url: https://github.com/pbrisbin/yaml-marked/archive/8fe21f6cf13b78f14c0fa41c84456b5dd32bd098.tar.gz
 snapshots:
 - completed:
-    sha256: caa77fdbc5b9f698262b21ee78030133272ec53116ad6ddbefdc4c321f668e0c
-    size: 640014
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/4.yaml
-  original: lts-21.4
+    sha256: 1b4c2669e26fa828451830ed4725e4d406acc25a1fa24fcc039465dd13d7a575
+    size: 714100
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/6.yaml
+  original: lts-22.6


### PR DESCRIPTION
Only code change is from the disappearance of the Either Alternative. It wasn't really being used meaningfully here anyway, since this function never returns `Left`.