### PR TITLE
update resolver, package with nix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,21 @@ jobs:
       - uses: ./
         with:
           arguments: --path test/examples/lts-18.18.yaml --no-exit
+
+  nix:
+    strategy:
+      matrix:
+        runner:
+          - ubuntu-latest
+          - macos-12
+          - macos-latest
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v26
+      - uses: cachix/cachix-action@v14
+        with:
+          name: freckle
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - name: Check
+        run: nix flake check --accept-flake-config --print-build-logs --keep-going

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         runner:
           - ubuntu-latest
-          - macOS-latest
+          - macos-12
 
       fail-fast: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
           - macos-12
           - macos-latest
     runs-on: ${{ matrix.runner }}
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v26

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "all-cabal-hashes": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1722379361,
+        "narHash": "sha256-VMUGBZGaiyDrikZh/t2/M7QKekOkK1auPtK2KmnakZ8=",
+        "owner": "commercialhaskell",
+        "repo": "all-cabal-hashes",
+        "rev": "69c9ea6a7746281865968fdccf00a07f5e1bdc04",
+        "type": "github"
+      },
+      "original": {
+        "owner": "commercialhaskell",
+        "ref": "hackage",
+        "repo": "all-cabal-hashes",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1722185531,
+        "narHash": "sha256-veKR07psFoJjINLC8RK4DiLniGGMgF3QMlS4tb74S6k=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "52ec9ac3b12395ad677e8b62106f0b98c1f8569d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pgp-wordlist": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1714149562,
+        "narHash": "sha256-WCFQgtWqq+gLst4lXkFYlmlW7L8PQOJfChsKMApy3Ng=",
+        "owner": "quchen",
+        "repo": "pgp-wordlist",
+        "rev": "1f0cfd90d62179952cbfd59c3405283a1d364272",
+        "type": "github"
+      },
+      "original": {
+        "owner": "quchen",
+        "repo": "pgp-wordlist",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "all-cabal-hashes": "all-cabal-hashes",
+        "nixpkgs": "nixpkgs",
+        "pgp-wordlist": "pgp-wordlist",
+        "stacklock2nix": "stacklock2nix"
+      }
+    },
+    "stacklock2nix": {
+      "locked": {
+        "lastModified": 1705051190,
+        "narHash": "sha256-xgH0gaD3dNtOzZzX3A40hZTiHJP5cIGmifbmfcS2OGI=",
+        "owner": "cdepillabout",
+        "repo": "stacklock2nix",
+        "rev": "22676dfc45fa1c33899ba1da1a23665172a18ba7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cdepillabout",
+        "repo": "stacklock2nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,22 +1,5 @@
 {
   "nodes": {
-    "all-cabal-hashes": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1722379361,
-        "narHash": "sha256-VMUGBZGaiyDrikZh/t2/M7QKekOkK1auPtK2KmnakZ8=",
-        "owner": "commercialhaskell",
-        "repo": "all-cabal-hashes",
-        "rev": "69c9ea6a7746281865968fdccf00a07f5e1bdc04",
-        "type": "github"
-      },
-      "original": {
-        "owner": "commercialhaskell",
-        "ref": "hackage",
-        "repo": "all-cabal-hashes",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1722185531,
@@ -51,7 +34,6 @@
     },
     "root": {
       "inputs": {
-        "all-cabal-hashes": "all-cabal-hashes",
         "nixpkgs": "nixpkgs",
         "pgp-wordlist": "pgp-wordlist",
         "stacklock2nix": "stacklock2nix"

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,106 @@
+{
+  inputs = {
+    nixpkgs = {
+      type = "github";
+      owner = "nixos";
+      repo = "nixpkgs";
+      ref = "nixos-unstable";
+    };
+    all-cabal-hashes = {
+      type = "github";
+      owner = "commercialhaskell";
+      repo = "all-cabal-hashes";
+      ref = "hackage";
+      flake = false;
+    };
+    stacklock2nix = {
+      type = "github";
+      owner = "cdepillabout";
+      repo = "stacklock2nix";
+    };
+    pgp-wordlist = {
+      type = "github";
+      owner = "quchen";
+      repo = "pgp-wordlist";
+      flake = false;
+    };
+  };
+
+  outputs = { self, nixpkgs, all-cabal-hashes, pgp-wordlist, stacklock2nix }:
+    let
+      supportedSystems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+
+      forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
+
+      nixpkgsFor =
+        forAllSystems (system: import nixpkgs {
+          inherit system;
+          overlays = [
+            stacklock2nix.overlay
+            self.overlays.default
+          ];
+        });
+    in
+    {
+      # The default package you get when you run `nix build` on this flake
+      defaultPackage = forAllSystems (system:
+        self.packages.${system}.stack-lint-extra-deps
+      );
+
+      # All packages provided by this flake
+      packages = forAllSystems (system: {
+        stack-lint-extra-deps = nixpkgsFor.${system}.stack-lint-extra-deps;
+      });
+
+      overlays.default = final: prev: {
+        stack-lint-extra-deps-stacklock = final.stacklock2nix {
+
+          stackYaml = ./stack.yaml;
+
+          # GHC version that matches stack.yaml
+          baseHaskellPkgSet = final.haskell.packages.ghc966;
+
+          # Use the Hackage package index
+          all-cabal-hashes = all-cabal-hashes;
+
+          additionalHaskellPkgSetOverrides = hfinal: hprev: {
+            # Workaround for unreleased updates
+            pgp-wordlist =
+              final.haskell.lib.dontCheck (hprev.callCabal2nix "pgp-wordlist" pgp-wordlist { });
+          } //
+          # Workarounds for issues in tests
+          nixpkgs.lib.genAttrs [
+            "ansi-wl-pprint"
+            "case-insensitive"
+            "integer-logarithms"
+            "lifted-base"
+            "prettyprinter"
+            "prettyprinter-compat-ansi-wl-pprint"
+            "primitive"
+            "quickcheck-instances"
+            "test-framework"
+            "uuid-types"
+            "yaml-marked"
+          ]
+            (name: final.haskell.lib.dontCheck hprev.${name});
+        };
+
+        stack-lint-extra-deps =
+          final.stack-lint-extra-deps-stacklock.pkgSet.stack-lint-extra-deps;
+      };
+    };
+
+  nixConfig = {
+    extra-substituters = [
+      "https://freckle.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "freckle.cachix.org-1:WnI1pZdwLf2vnP9Fx7OGbVSREqqi4HM2OhNjYmZ7odo="
+    ];
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,13 @@
     };
   };
 
-  outputs = { self, nixpkgs, pgp-wordlist, stacklock2nix }:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      pgp-wordlist,
+      stacklock2nix,
+    }:
     let
       supportedSystems = [
         "aarch64-darwin"
@@ -30,14 +36,16 @@
 
       forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
 
-      nixpkgsFor =
-        forAllSystems (system: import nixpkgs {
+      nixpkgsFor = forAllSystems (
+        system:
+        import nixpkgs {
           inherit system;
           overlays = [
             stacklock2nix.overlay
             self.overlays.default
           ];
-        });
+        }
+      );
     in
     {
       # All packages provided by this flake
@@ -62,7 +70,8 @@
             sha256 = "1l9k4sg7pigr73749h4nkldllvl36d86sghjb5ibqpckkrbr3yky";
           };
 
-          additionalHaskellPkgSetOverrides = hfinal: hprev:
+          additionalHaskellPkgSetOverrides =
+            hfinal: hprev:
             # Workarounds for issues in tests
             nixpkgs.lib.genAttrs [
               "ansi-wl-pprint"
@@ -76,21 +85,15 @@
               "test-framework"
               "uuid-types"
               "yaml-marked"
-            ]
-              (name: final.haskell.lib.dontCheck hprev.${name});
+            ] (name: final.haskell.lib.dontCheck hprev.${name});
         };
 
-        stack-lint-extra-deps =
-          final.stack-lint-extra-deps-stacklock.pkgSet.stack-lint-extra-deps;
+        stack-lint-extra-deps = final.stack-lint-extra-deps-stacklock.pkgSet.stack-lint-extra-deps;
       };
     };
 
   nixConfig = {
-    extra-substituters = [
-      "https://freckle.cachix.org"
-    ];
-    extra-trusted-public-keys = [
-      "freckle.cachix.org-1:WnI1pZdwLf2vnP9Fx7OGbVSREqqi4HM2OhNjYmZ7odo="
-    ];
+    extra-substituters = [ "https://freckle.cachix.org" ];
+    extra-trusted-public-keys = [ "freckle.cachix.org-1:WnI1pZdwLf2vnP9Fx7OGbVSREqqi4HM2OhNjYmZ7odo=" ];
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -54,11 +54,12 @@
           # GHC version that matches stack.yaml
           baseHaskellPkgSet = final.haskell.packages.ghc966;
 
-          all-cabal-hashes = final.fetchFromGitHub {
-            owner = "commercialhaskell";
-            repo = "all-cabal-hashes";
-            rev = "69c9ea6a7746281865968fdccf00a07f5e1bdc04";
-            sha256 = "sha256-VMUGBZGaiyDrikZh/t2/M7QKekOkK1auPtK2KmnakZ8=";
+          # It is necessary to get this using a fetcher that doesn't unpack to
+          # preserve hash compatibility among case (in/)sensitive file systems.
+          all-cabal-hashes = final.fetchurl {
+            name = "all-cabal-hashes";
+            url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/69c9ea6a7746281865968fdccf00a07f5e1bdc04.tar.gz";
+            sha256 = "1l9k4sg7pigr73749h4nkldllvl36d86sghjb5ibqpckkrbr3yky";
           };
 
           additionalHaskellPkgSetOverrides = hfinal: hprev:

--- a/flake.nix
+++ b/flake.nix
@@ -47,13 +47,9 @@
         });
     in
     {
-      # The default package you get when you run `nix build` on this flake
-      defaultPackage = forAllSystems (system:
-        self.packages.${system}.stack-lint-extra-deps
-      );
-
       # All packages provided by this flake
-      packages = forAllSystems (system: {
+      packages = forAllSystems (system: rec {
+        default = stack-lint-extra-deps;
         stack-lint-extra-deps = nixpkgsFor.${system}.stack-lint-extra-deps;
       });
 

--- a/flake.nix
+++ b/flake.nix
@@ -61,26 +61,22 @@
             sha256 = "sha256-VMUGBZGaiyDrikZh/t2/M7QKekOkK1auPtK2KmnakZ8=";
           };
 
-          additionalHaskellPkgSetOverrides = hfinal: hprev: {
-            # Workaround for unreleased updates
-            pgp-wordlist =
-              final.haskell.lib.dontCheck (hprev.callCabal2nix "pgp-wordlist" pgp-wordlist { });
-          } //
-          # Workarounds for issues in tests
-          nixpkgs.lib.genAttrs [
-            "ansi-wl-pprint"
-            "case-insensitive"
-            "integer-logarithms"
-            "lifted-base"
-            "prettyprinter"
-            "prettyprinter-compat-ansi-wl-pprint"
-            "primitive"
-            "quickcheck-instances"
-            "test-framework"
-            "uuid-types"
-            "yaml-marked"
-          ]
-            (name: final.haskell.lib.dontCheck hprev.${name});
+          additionalHaskellPkgSetOverrides = hfinal: hprev:
+            # Workarounds for issues in tests
+            nixpkgs.lib.genAttrs [
+              "ansi-wl-pprint"
+              "case-insensitive"
+              "integer-logarithms"
+              "lifted-base"
+              "prettyprinter"
+              "prettyprinter-compat-ansi-wl-pprint"
+              "primitive"
+              "quickcheck-instances"
+              "test-framework"
+              "uuid-types"
+              "yaml-marked"
+            ]
+              (name: final.haskell.lib.dontCheck hprev.${name});
         };
 
         stack-lint-extra-deps =

--- a/flake.nix
+++ b/flake.nix
@@ -65,7 +65,10 @@
           # GHC version that matches stack.yaml
           baseHaskellPkgSet = final.haskell.packages.ghc966;
 
-          # Use the Hackage package index
+          # Use the latest version of the Hackage package index.
+          # To update this (akin to running 'cabal update'), run:
+          #
+          #   nix flake lock --update-input all-cabal-hashes
           all-cabal-hashes = all-cabal-hashes;
 
           additionalHaskellPkgSetOverrides = hfinal: hprev: {

--- a/flake.nix
+++ b/flake.nix
@@ -6,13 +6,6 @@
       repo = "nixpkgs";
       ref = "nixos-unstable";
     };
-    all-cabal-hashes = {
-      type = "github";
-      owner = "commercialhaskell";
-      repo = "all-cabal-hashes";
-      ref = "hackage";
-      flake = false;
-    };
     stacklock2nix = {
       type = "github";
       owner = "cdepillabout";
@@ -26,7 +19,7 @@
     };
   };
 
-  outputs = { self, nixpkgs, all-cabal-hashes, pgp-wordlist, stacklock2nix }:
+  outputs = { self, nixpkgs, pgp-wordlist, stacklock2nix }:
     let
       supportedSystems = [
         "aarch64-darwin"
@@ -61,11 +54,12 @@
           # GHC version that matches stack.yaml
           baseHaskellPkgSet = final.haskell.packages.ghc966;
 
-          # Use the latest version of the Hackage package index.
-          # To update this (akin to running 'cabal update'), run:
-          #
-          #   nix flake lock --update-input all-cabal-hashes
-          all-cabal-hashes = all-cabal-hashes;
+          all-cabal-hashes = final.fetchFromGitHub {
+            owner = "commercialhaskell";
+            repo = "all-cabal-hashes";
+            rev = "69c9ea6a7746281865968fdccf00a07f5e1bdc04";
+            sha256 = "sha256-VMUGBZGaiyDrikZh/t2/M7QKekOkK1auPtK2KmnakZ8=";
+          };
 
           additionalHaskellPkgSetOverrides = hfinal: hprev: {
             # Workaround for unreleased updates

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,6 @@
-resolver: lts-22.6
+resolver: lts-22.31
+packages:
+  - .
 extra-deps:
   - github: pbrisbin/yaml-marked
     commit: 8fe21f6cf13b78f14c0fa41c84456b5dd32bd098

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -17,7 +17,7 @@ packages:
     url: https://github.com/pbrisbin/yaml-marked/archive/8fe21f6cf13b78f14c0fa41c84456b5dd32bd098.tar.gz
 snapshots:
 - completed:
-    sha256: 1b4c2669e26fa828451830ed4725e4d406acc25a1fa24fcc039465dd13d7a575
-    size: 714100
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/6.yaml
-  original: lts-22.6
+    sha256: acaab6ca693211938d1542abcb1c83a2f298b9f6b571854a9d38febe39b6408e
+    size: 719577
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/31.yaml
+  original: lts-22.31


### PR DESCRIPTION
If you want to try out the Nix package, you can run:

```
nix shell \
  'github:freckle/stack-lint-extra-deps?ref=chris/pkg' \
  --command stack-lint-extra-deps --help
```

It should just download the pre-built binary the Freckle public cache (if the github actions for your platform have finished running).

This is my first time trying out [stacklock2nix](https://github.com/cdepillabout/stacklock2nix); it seems pretty okay.

Tagging Pat plus anyone Nix-using or Nix-curious.