### PR TITLE
fix --version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/stack-lint-extra-deps/compare/v1.2.2.0...main)
+## [_Unreleased_](https://github.com/freckle/stack-lint-extra-deps/compare/v1.2.2.1...main)
+
+## [v1.2.2.0](https://github.com/freckle/stack-lint-extra-deps/compare/v1.2.2.0...v1.2.2.1)
+
+- Fix `--version` to work without a `stack.yaml` present
 
 ## [v1.2.2.0](https://github.com/freckle/stack-lint-extra-deps/compare/v1.2.1.0...v1.2.2.0)
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,12 +5,17 @@ module Main
 import SLED.Prelude
 
 import Blammo.Logging.Simple
+import Data.Version (showVersion)
+import Paths_stack_lint_extra_deps (version)
 import SLED.App
 import SLED.Options.Parse
 import SLED.Run
 
 main :: IO ()
-main = do
-  opts <- parseOptions
-  logger <- newLoggerEnv
-  runAppT (runSLED opts) logger
+main =
+  parseOptions >>= \case
+    Left PrintVersion ->
+      putStrLn $ "stack-lint-extra-deps-" <> showVersion version
+    Right opts -> do
+      logger <- newLoggerEnv
+      runAppT (runSLED opts) logger

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: stack-lint-extra-deps
-version: 1.2.2.0
+version: 1.2.2.1
 
 extra-doc-files:
   - README.md

--- a/src/SLED/Run.hs
+++ b/src/SLED/Run.hs
@@ -15,8 +15,6 @@ import Blammo.Logging.Logger
 import Conduit
 import Data.Conduit.Combinators (iterM)
 import qualified Data.List.NonEmpty as NE
-import Data.Version (showVersion)
-import Paths_stack_lint_extra_deps (version)
 import SLED.Check
 import SLED.Checks
 import SLED.Options.Parse
@@ -38,9 +36,6 @@ runSLED
      )
   => Options
   -> m ()
-runSLED options
-  | options.version =
-      liftIO $ putStrLn $ "stack-lint-extra-deps-" <> showVersion version
 runSLED options = do
   logDebug $ "Loaded stack.yaml" :# ["path" .= options.path]
 

--- a/stack-lint-extra-deps.cabal
+++ b/stack-lint-extra-deps.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           stack-lint-extra-deps
-version:        1.2.2.0
+version:        1.2.2.1
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple


### PR DESCRIPTION
That was stupid; as soon as I tested `--version` *outside of* this repo, I realized that it's eagerly parsing too much, and it fails if there's no `stack.yaml` present. This fixes it so that the program quits immediately if `--version` is given without inspecting anything else.
