### PR TITLE
Parse trailing comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/stack-lint-extra-deps/compare/v1.2.2.1...main)
+## [_Unreleased_](https://github.com/freckle/stack-lint-extra-deps/compare/v1.2.3.0...main)
+
+## [v1.2.3.0](https://github.com/freckle/stack-lint-extra-deps/compare/v1.2.2.1...v1.2.3.1)
+
+- Parse `@sled` pragmas from trailing comments too
 
 ## [v1.2.2.0](https://github.com/freckle/stack-lint-extra-deps/compare/v1.2.2.0...v1.2.2.1)
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: stack-lint-extra-deps
-version: 1.2.2.1
+version: 1.2.3.1
 
 extra-doc-files:
   - README.md

--- a/src/SLED/Options/Pragma.hs
+++ b/src/SLED/Options/Pragma.hs
@@ -25,7 +25,7 @@ fromComment bs =
   unpack <$> do
     c <-
       T.stripPrefix "# "
-        . T.dropWhile isSpace
+        . T.dropWhile (/= '#')
         $ decodeUtf8With lenientDecode bs
     T.stripPrefix "@sled " $ T.dropWhile isSpace c
 

--- a/stack-lint-extra-deps.cabal
+++ b/stack-lint-extra-deps.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
 name:           stack-lint-extra-deps
-version:        1.2.2.1
+version:        1.2.3.1
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple

--- a/test/SLED/Options/PragmaSpec.hs
+++ b/test/SLED/Options/PragmaSpec.hs
@@ -48,6 +48,22 @@ spec = do
 
       options.excludes `shouldBe` ["foo", "baz", "bat"]
 
+    it "parses trailing comments" $ do
+      let
+        yaml :: ByteString
+        yaml =
+          mconcat
+            [ "resolver: x\n"
+            , "extra-deps:\n"
+            , "  - foo\n"
+            , "  - bar\n"
+            , "  - bat # @sled --exclude=\"bat\"\n"
+            ]
+
+      let (_errs, options) = parsePragmaOptions yaml
+
+      options.excludes `shouldBe` ["bat"]
+
     it "returns errors in the case of invalid options" $ do
       let
         yaml :: ByteString


### PR DESCRIPTION
This updates our "parser" to look for comments anywhere on the line,
rather than only on lines by themselves. It is a little less rebust:

```yaml
# @sled <we got this before>
example1:

example2: # @sled <we'll get this now too>

example3: |
  # @sled <we *incorrectly* got this before>

example4: "xxx# @sled <we'll incorrectly get this now too>"
```

I think, given the lack of random strings as useful or valid in a
`stack.yaml`, as well as the `@sled` requirement, this is perfectly
acceptable.
