### PR TITLE
Fix parsing of Hackage deps with checksum

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,19 +36,22 @@ jobs:
         include:
           - os: ubuntu-latest
             suffix: x86_64-linux
-          - os: macOS-latest
+          - os: macos-12
             suffix: x86_64-osx
+          - os: macos-latest
+            suffix: arm64-osx
 
     runs-on: ${{ matrix.os }}
     steps:
-      - if: ${{ runner.os == 'macOS' }}
-        run: |
-          curl -SsL https://get.haskellstack.org | sh
       - uses: actions/checkout@v4
-      - uses: freckle/stack-cache-action@v2
       - run: |
           mkdir -p dist/stack-lint-extra-deps
-          stack build --copy-bins --local-bin-path dist/stack-lint-extra-deps
+      - id: stack
+        uses: freckle/stack-action@v5
+        with:
+          build-arguments: >-
+            --local-bin-path ./dist/stack-lint-extra-deps
+      - run: |
           tar -C dist -czf ./stack-lint-extra-deps-${{ matrix.suffix }}.tar.gz ./stack-lint-extra-deps
       - uses: freckle/action-gh-release@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/stack-lint-extra-deps/compare/v1.2.4.0...main)
+## [_Unreleased_](https://github.com/freckle/stack-lint-extra-deps/compare/v1.2.4.1...main)
+
+## [v1.2.4.1](https://github.com/freckle/stack-lint-extra-deps/compare/v1.2.4.0...v1.2.4.1)
+
+- Don't fail with a parse error in the presence of Hackage checksums
 
 ## [v1.2.4.0](https://github.com/freckle/stack-lint-extra-deps/compare/v1.2.3.1...v1.2.4.0)
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: stack-lint-extra-deps
-version: 1.2.4.0
+version: 1.2.4.1
 
 extra-doc-files:
   - README.md

--- a/src/SLED/Version.hs
+++ b/src/SLED/Version.hs
@@ -59,27 +59,29 @@ parseVersion =
 parseWithRevision :: ReadP Version
 parseWithRevision = do
   v <- V.parseVersion
-  r <- string "@rev:" *> digits
+  r <- string "@rev:" *> nat
   pure
     Version
       { version = v
-      , revision = Just $ Unsafe.read r
+      , revision = Just r
       }
- where
-  digits = many1 $ satisfy isDigit
 
 parseWithChecksum :: ReadP Version
 parseWithChecksum = do
   v <- V.parseVersion
   -- just discarded for now, but here if we want it later
-  _checksum <- char '@' *> many1 hex
+  _checksum <- string "@sha256:" *> hexes <* char ',' <* nat
   pure
     Version
       { version = v
       , revision = Nothing
       }
- where
-  hex = satisfy isHexDigit
+
+nat :: ReadP Natural
+nat = fmap Unsafe.read $ many1 $ satisfy isDigit
+
+hexes :: ReadP String
+hexes = many1 $ satisfy isHexDigit
 
 parseSimple :: ReadP Version
 parseSimple =

--- a/stack-lint-extra-deps.cabal
+++ b/stack-lint-extra-deps.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           stack-lint-extra-deps
-version:        1.2.4.0
+version:        1.2.4.1
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple

--- a/test/SLED/Checks/HackageSpec.hs
+++ b/test/SLED/Checks/HackageSpec.hs
@@ -113,6 +113,25 @@ spec = do
           }
         `shouldReturn` Nothing
 
+    it "does not suggest when the extra-dep is a newer revision (checksum)" $ do
+      let
+        package = PackageName "servant-swagger-ui-core"
+        version = unsafeVersion "0.3.5@sha256:ffffffffffffffffff,100"
+        mockHackage = Map.singleton package $ hackageVersions ["0.3.5@rev:11"] [] []
+        mockStackage =
+          Map.singleton
+            (markedItem lts1818)
+            (Map.singleton package $ stackageVersions "0.3.5@rev:6" "0.3.5@rev:11")
+
+      runHackageChecks
+        mockHackage
+        mockStackage
+        HackageExtraDep
+          { package = package
+          , version = Just version
+          }
+        `shouldReturn` Nothing
+
     it "does not suggest when the extra-dep is a newer revision (explicit)" $ do
       let
         package = PackageName "servant-swagger-ui-core"


### PR DESCRIPTION
When refactoring to handle `@rev:`, I got the (ignored) parse of a
checksum wrong. I thought it was just `@<checksum>`, but it's actually
`@sha256:<checksum>,<length>`. This patch adds a test and fix.

Checksum values are ignored by SLED, but the parse failure would prevent
loading any `.stack.yaml` that contained one. That said, I can't even
find documentation on checksums anymore, since Stack has moved away from
recommending them, so hopefully not many users were affected.
