### PR TITLE
Emit suggestion on out of date resolver

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -10,6 +10,7 @@
 - ignore: {name: "Use ||"}  # we like "or" at 3+ elements
 - ignore: {name: "Use join"}  # this often leads to cryptic code when do notation is easier to read
 - ignore: {name: "Redundant ^."}  # commonly broken by esqueleto
+- ignore: {name: "Functor law"}  # too aggressive
 
 # Custom Warnings
 - warn: {lhs: mapM, rhs: traverse}

--- a/README.md
+++ b/README.md
@@ -36,19 +36,23 @@ url=$(curl --silent https://api.github.com/repos/freckle/stack-lint-extra-deps/r
 ```console
 % stack lint-extra-deps --help
 Usage: stack-lint-extra-deps [-p|--path PATH] [-r|--resolver RESOLVER]
-                             [--exclude PATTERN] [--checks CHECKS]
-                             [-n|--no-exit] [PATTERN]
+                             [-f|--format tty|gha|json] [--exclude PATTERN]
+                             [-R|--no-check-resolver] [--checks CHECKS]
+                             [-n|--no-exit] [-F|--fix] [PATTERN] [--version]
 
-  Lint Stackage (extra) Deps
+  stack lint-extra-deps (sled)
 
 Available options:
-  -p,--path PATH           Path to config to lint (default: "stack.yaml")
+  -p,--path PATH           Path to config to lint
   -r,--resolver RESOLVER   Resolver to use, default is read from --path
+  -f,--format tty|gha|json Format to output in
   --exclude PATTERN        Exclude deps matching PATTERN
-  --checks CHECKS          Checks to run, one of: all, git, hackage
-                           (default: all)
+  -R,--no-check-resolver   Don't check for out of date resolver
+  --checks CHECKS          Checks to run, one of: none, all, git, hackage
   -n,--no-exit             Exit successfully, even if suggestions found
+  -F,--fix                 Automatically fix problems
   PATTERN                  Limit to deps matching PATTERN
+  --version                Print version number information and quit
   -h,--help                Show this help text
 ```
 

--- a/src/SLED/App.hs
+++ b/src/SLED/App.hs
@@ -16,6 +16,7 @@ import SLED.GitDetails
 import SLED.Hackage
 import SLED.PackageName
 import SLED.Stackage
+import qualified SLED.Stackage.Snapshots as Stackage
 import SLED.StackageResolver
 import System.Process.Typed
 import UnliftIO.Exception (throwIO)
@@ -58,7 +59,7 @@ instance MonadIO m => MonadHackage (AppT app m) where
 
     pure $ hush eVersions
 
-instance MonadIO m => MonadStackage (AppT app m) where
+instance MonadUnliftIO m => MonadStackage (AppT app m) where
   getStackageVersions resolver package = do
     eStackageVersions <-
       httpParse parseStackageVersions
@@ -66,7 +67,7 @@ instance MonadIO m => MonadStackage (AppT app m) where
           ( parseRequest
               $ unpack
               $ "https://www.stackage.org/"
-              <> resolver.unwrap
+              <> stackageResolverToText resolver
               <> "/package/"
               <> package.unwrap
           )
@@ -79,6 +80,8 @@ instance MonadIO m => MonadStackage (AppT app m) where
          ]
 
     pure $ hush eStackageVersions
+
+  getLatestInSeries = Stackage.getLatestInSeries
 
 instance MonadIO m => MonadGit (AppT app m) where
   gitClone url path = runGit ["clone", "--quiet", url, path]

--- a/src/SLED/App.hs
+++ b/src/SLED/App.hs
@@ -59,7 +59,7 @@ instance MonadIO m => MonadHackage (AppT app m) where
 
     pure $ hush eVersions
 
-instance MonadUnliftIO m => MonadStackage (AppT app m) where
+instance MonadIO m => MonadStackage (AppT app m) where
   getStackageVersions resolver package = do
     eStackageVersions <-
       httpParse parseStackageVersions

--- a/src/SLED/Check.hs
+++ b/src/SLED/Check.hs
@@ -18,5 +18,5 @@ import SLED.Stackage as X
 import SLED.Suggestion as X
 
 newtype Check = Check
-  { run :: ExternalDetails -> ExtraDep -> Maybe SuggestionAction
+  { run :: ExternalDetails -> ExtraDep -> Maybe (SuggestionAction ExtraDep)
   }

--- a/src/SLED/Checks.hs
+++ b/src/SLED/Checks.hs
@@ -15,12 +15,15 @@ import SLED.Checks.RedundantHackage
 import SLED.Options.BoundedEnum
 
 data ChecksName
-  = AllChecks
+  = NoChecks
+  | AllChecks
   | GitChecks
   | HackageChecks
   deriving stock (Bounded, Enum)
 
 instance Semigroup ChecksName where
+  NoChecks <> x = x
+  x <> NoChecks = x
   AllChecks <> _ = AllChecks
   _ <> AllChecks = AllChecks
   GitChecks <> HackageChecks = AllChecks
@@ -40,12 +43,14 @@ checksNameOption =
 
 showChecksName :: ChecksName -> String
 showChecksName = \case
+  NoChecks -> "none"
   AllChecks -> "all"
   GitChecks -> "git"
   HackageChecks -> "hackage"
 
 checksByName :: ChecksName -> [Check]
 checksByName = \case
+  NoChecks -> []
   AllChecks -> checksByName GitChecks <> checksByName HackageChecks
   GitChecks -> [checkRedundantGit, checkGitVersion]
   HackageChecks -> [checkRedundantHackage, checkHackageVersion]

--- a/src/SLED/Checks/StackageResolver.hs
+++ b/src/SLED/Checks/StackageResolver.hs
@@ -1,0 +1,28 @@
+module SLED.Checks.StackageResolver
+  ( checkStackageResolver
+  ) where
+
+import SLED.Prelude
+
+import SLED.Stackage
+import SLED.StackageResolver
+import SLED.Suggestion
+
+checkStackageResolver
+  :: (Monad m, MonadStackage m)
+  => Marked StackageResolver
+  -> m (Maybe (Marked (Suggestion StackageResolver)))
+checkStackageResolver mresolver = do
+  latest <- getLatestInSeries resolver
+  let suggestion = (`replaceWith` latest) <$> mresolver
+  pure $ suggestion <$ guard (latest > resolver)
+ where
+  resolver :: StackageResolver
+  resolver = markedItem mresolver
+
+replaceWith :: t -> t -> Suggestion t
+replaceWith a b =
+  Suggestion
+    { target = a
+    , action = ReplaceWith b
+    }

--- a/src/SLED/GitDetails.hs
+++ b/src/SLED/GitDetails.hs
@@ -10,7 +10,6 @@ import SLED.Prelude
 
 import qualified Data.ByteString.Lazy as BSL
 import Data.Char (isSpace)
-import Data.List.Extra (dropPrefix)
 import qualified Data.Text as T
 import SLED.GitExtraDep
 import SLED.Version
@@ -98,7 +97,7 @@ gitTaggedVersions = do
   toPair x = case T.words x of
     [ref, sha] -> do
       tag <- T.stripPrefix "refs/tags/" ref
-      version <- parseVersion $ dropPrefix "v" $ unpack tag
+      version <- parseVersion $ dropPrefix "v" tag
       pure (CommitSHA sha, version)
     _ -> Nothing
 
@@ -112,3 +111,6 @@ bsToInt = readMaybe . unpack . T.dropWhileEnd isSpace . bsToText
 
 bsToText :: BSL.ByteString -> Text
 bsToText = decodeUtf8With lenientDecode . BSL.toStrict
+
+dropPrefix :: Text -> Text -> Text
+dropPrefix p t = fromMaybe t $ T.stripPrefix p t

--- a/src/SLED/HackageExtraDep.hs
+++ b/src/SLED/HackageExtraDep.hs
@@ -41,7 +41,7 @@ splitPackageVersion x =
   fromMaybe (x, Nothing)
     $ headMaybe
     $ filter (isJust . snd)
-    $ map (second (parseVersion . unpack))
+    $ map (second parseVersion)
     $ breaksOn '-' x
 
 -- |

--- a/src/SLED/Options.hs
+++ b/src/SLED/Options.hs
@@ -48,7 +48,7 @@ optionsParser =
         )
     <*> ( Last
             <$> optional
-              ( StackageResolver
+              ( readStackageResolver
                   <$> strOption
                     ( short 'r'
                         <> long "resolver"
@@ -94,6 +94,5 @@ optionsParser =
         )
     <*> ( Any
             <$> switch
-              ( long "version" <> help "Print version number information and quit"
-              )
+              (long "version" <> help "Print version number information and quit")
         )

--- a/src/SLED/Options.hs
+++ b/src/SLED/Options.hs
@@ -19,6 +19,7 @@ data Options = Options
   , resolver :: Last StackageResolver
   , format :: Last Format
   , excludes :: [Pattern]
+  , noCheckResolver :: Any
   , checks :: Maybe ChecksName
   , noExit :: Any
   , filter :: Last Pattern
@@ -75,6 +76,13 @@ optionsParser =
               <> metavar "PATTERN"
           )
       )
+    <*> ( Any
+            <$> switch
+              ( short 'R'
+                  <> long "no-check-resolver"
+                  <> help "Don't check for out of date resolver"
+              )
+        )
     <*> optional checksNameOption
     <*> ( Any
             <$> switch

--- a/src/SLED/Options/Parse.hs
+++ b/src/SLED/Options/Parse.hs
@@ -23,6 +23,7 @@ data Options = Options
   , resolver :: Marked StackageResolver
   , format :: Format
   , excludes :: [Pattern]
+  , checkResolver :: Bool
   , checks :: ChecksName
   , noExit :: Bool
   , filter :: Maybe Pattern
@@ -63,6 +64,7 @@ parseOptions = do
             , resolver = resolver
             , format = fromMaybe defaultFormat $ getLast options.format
             , excludes = options.excludes
+            , checkResolver = not $ getAny options.noCheckResolver
             , checks = fromMaybe AllChecks $ options.checks
             , noExit = getAny options.noExit
             , filter = getLast options.filter

--- a/src/SLED/Parse.hs
+++ b/src/SLED/Parse.hs
@@ -16,14 +16,6 @@ import SLED.Prelude
 import Data.Char (isDigit, isHexDigit)
 import qualified Data.List.NonEmpty as NE
 import Text.ParserCombinators.ReadP
-  ( ReadP
-  , char
-  , eof
-  , many1
-  , readP_to_S
-  , satisfy
-  , string
-  )
 import qualified Prelude as Unsafe (read)
 
 parse :: ReadP a -> Text -> Maybe a

--- a/src/SLED/Parse.hs
+++ b/src/SLED/Parse.hs
@@ -1,0 +1,42 @@
+module SLED.Parse
+  ( ReadP
+  , parse
+  , parseOr
+  , string
+  , char
+  , anyChar
+  , nat
+  , hexes
+  , many1
+  )
+where
+
+import SLED.Prelude
+
+import Data.Char (isDigit, isHexDigit)
+import qualified Data.List.NonEmpty as NE
+import Text.ParserCombinators.ReadP
+  ( ReadP
+  , char
+  , eof
+  , many1
+  , readP_to_S
+  , satisfy
+  , string
+  )
+import qualified Prelude as Unsafe (read)
+
+parse :: ReadP a -> Text -> Maybe a
+parse p = fmap (fst . NE.last) . nonEmpty . readP_to_S (p <* eof) . unpack
+
+parseOr :: ReadP a -> a -> Text -> a
+parseOr p def = maybe def (fst . NE.last) . nonEmpty . readP_to_S (p <* eof) . unpack
+
+nat :: ReadP Natural
+nat = fmap Unsafe.read $ many1 $ satisfy isDigit
+
+hexes :: ReadP String
+hexes = many1 $ satisfy isHexDigit
+
+anyChar :: ReadP Char
+anyChar = satisfy $ const True

--- a/src/SLED/Run.hs
+++ b/src/SLED/Run.hs
@@ -17,10 +17,12 @@ import Data.Conduit.Combinators (iterM)
 import qualified Data.List.NonEmpty as NE
 import SLED.Check
 import SLED.Checks
+import SLED.Checks.StackageResolver
 import SLED.Options.Parse
 import SLED.StackYaml
 import SLED.StackageResolver
 import SLED.Suggestion.Format
+import SLED.Suggestion.Format.Target
 import System.FilePath.Glob
 import UnliftIO.Directory (getCurrentDirectory)
 
@@ -39,26 +41,44 @@ runSLED
 runSLED options = do
   logDebug $ "Loaded stack.yaml" :# ["path" .= options.path]
 
-  cwd <- getCurrentDirectory
-  colors <- getColorsLogger
+  n <-
+    fmap getSum
+      $ runConduit
+      $ (<>)
+      <$> do
+        msuggestion <- lift $ checkStackageResolver options.stackYaml.resolver
+        traverse_ yield msuggestion
+          .| outputSuggestions options.stackYamlContents options.format
+          .| foldMapC (const @(Sum Int) 1)
+      <*> do
+        yieldMany options.stackYaml.extraDeps
+          .| filterC (shouldIncludeExtraDep options.filter options.excludes . markedItem)
+          .| concatMapMC (runChecks options.resolver options.checks)
+          .| outputSuggestions options.stackYamlContents options.format
+          .| foldMapC (const @(Sum Int) 1)
 
-  suggestions <-
-    runConduit
-      $ yieldMany options.stackYaml.extraDeps
-      .| filterC (shouldIncludeExtraDep options.filter options.excludes . markedItem)
-      .| concatMapMC (runChecks options.resolver options.checks)
-      .| iterM
-        ( pushLoggerLn
-            . formatSuggestion cwd options.stackYamlContents colors options.format
-        )
-      .| sinkList
-
-  let n = length suggestions
   logDebug $ "Suggestions found" :# ["count" .= n]
 
   when (n /= 0 && not options.noExit) $ do
     logDebug "Exiting non-zero (--no-exit to disable)"
     exitFailure
+
+-- | Print 'Suggestion's according to 'Format'
+outputSuggestions
+  :: ( MonadUnliftIO m
+     , MonadLogger m
+     , MonadReader env m
+     , HasLogger env
+     , IsTarget t
+     , ToJSON t
+     )
+  => ByteString
+  -> Format
+  -> ConduitT (Marked (Suggestion t)) (Marked (Suggestion t)) m ()
+outputSuggestions contents format = do
+  cwd <- getCurrentDirectory
+  colors <- getColorsLogger
+  iterM $ pushLoggerLn . formatSuggestion cwd contents colors format
 
 shouldIncludeExtraDep :: Maybe Pattern -> [Pattern] -> ExtraDep -> Bool
 shouldIncludeExtraDep mInclude excludes dep
@@ -76,7 +96,7 @@ runChecks
   => Marked StackageResolver
   -> ChecksName
   -> Marked ExtraDep
-  -> m (Maybe (Marked Suggestion))
+  -> m (Maybe (Marked (Suggestion ExtraDep)))
 runChecks (markedItem -> resolver) checksName m@(markedItem -> extraDep) = do
   logDebug $ "Fetching external details" :# ["dependency" .= extraDep]
 

--- a/src/SLED/Stackage.hs
+++ b/src/SLED/Stackage.hs
@@ -24,6 +24,8 @@ class MonadStackage m where
   getStackageVersions
     :: StackageResolver -> PackageName -> m (Maybe StackageVersions)
 
+  getLatestInSeries :: StackageResolver -> m StackageResolver
+
 data StackageVersions = StackageVersions
   { onPage :: Version
   , onHackage :: Version
@@ -50,9 +52,9 @@ parseVersionsTable cursor = do
   toPair = \case
     [] -> Nothing
     [_] -> Nothing
-    [k, v] -> (k,) <$> parseVersion (unpack v)
-    [k, _, v] -> (k,) <$> parseVersion (unpack v)
-    (k : v : _) -> (k,) <$> parseVersion (unpack v)
+    [k, v] -> (k,) <$> parseVersion v
+    [k, _, v] -> (k,) <$> parseVersion v
+    (k : v : _) -> (k,) <$> parseVersion v
 
   fixNightly m =
     maybe m (\(_, v) -> Map.insertWith (\_new old -> old) currentKey v m)

--- a/src/SLED/Stackage/Snapshots.hs
+++ b/src/SLED/Stackage/Snapshots.hs
@@ -9,7 +9,7 @@ import Network.HTTP.Simple
 import SLED.StackageResolver
 import UnliftIO.Exception (try)
 
-getLatestInSeries :: MonadUnliftIO m => StackageResolver -> m StackageResolver
+getLatestInSeries :: MonadIO m => StackageResolver -> m StackageResolver
 getLatestInSeries x = maybe x (.resolver) <$> getFirstSnapshotMatching sameSeries
  where
   sameSeries :: Snapshot -> Bool
@@ -45,7 +45,7 @@ snapshotPageLength :: SnapshotPage -> Int
 snapshotPageLength = length . concat . (.snapshots)
 
 getFirstSnapshotMatching
-  :: MonadUnliftIO m => (Snapshot -> Bool) -> m (Maybe Snapshot)
+  :: MonadIO m => (Snapshot -> Bool) -> m (Maybe Snapshot)
 getFirstSnapshotMatching p = go 0 1
  where
   go seenSoFar page = do
@@ -58,11 +58,10 @@ getFirstSnapshotMatching p = go 0 1
       Right {} -> pure Nothing
 
 getSnapshotsPage
-  :: MonadUnliftIO m => Int -> m (Either HttpException SnapshotPage)
-getSnapshotsPage page = try $ do
+  :: MonadIO m => Int -> m (Either HttpException SnapshotPage)
+getSnapshotsPage page = liftIO $ try $ do
   req <-
-    liftIO
-      $ parseRequestThrow
+    parseRequestThrow
       $ "http://www.stackage.org/snapshots?page="
       <> show page
   resp <- httpJSON req

--- a/src/SLED/Stackage/Snapshots.hs
+++ b/src/SLED/Stackage/Snapshots.hs
@@ -1,0 +1,69 @@
+module SLED.Stackage.Snapshots
+  ( getLatestInSeries
+  ) where
+
+import SLED.Prelude
+
+import Data.Aeson (withArray)
+import Network.HTTP.Simple
+import SLED.StackageResolver
+import UnliftIO.Exception (try)
+
+getLatestInSeries :: MonadUnliftIO m => StackageResolver -> m StackageResolver
+getLatestInSeries x = maybe x (.resolver) <$> getFirstSnapshotMatching sameSeries
+ where
+  sameSeries :: Snapshot -> Bool
+  sameSeries s = s.resolver `stackageResolverSameSeries` x
+
+data Snapshot = Snapshot
+  { resolver :: StackageResolver
+  , _description :: Text
+  , _since :: Text
+  }
+
+instance FromJSON Snapshot where
+  parseJSON = withArray "Snapshot" $ \vs ->
+    case toList vs of
+      [resolver, description, since] ->
+        Snapshot
+          <$> parseJSON resolver
+          <*> parseJSON description
+          <*> parseJSON since
+      _ -> fail $ "Snapshots are encoded as a list of 3 elements, saw " <> show vs
+
+data SnapshotPage = SnapshotPage
+  { snapshots :: [[Snapshot]]
+  , totalCount :: Int
+  }
+  deriving stock (Generic)
+  deriving anyclass (FromJSON)
+
+findSnapshotPage :: (Snapshot -> Bool) -> SnapshotPage -> Maybe Snapshot
+findSnapshotPage p = find p . concat . (.snapshots)
+
+snapshotPageLength :: SnapshotPage -> Int
+snapshotPageLength = length . concat . (.snapshots)
+
+getFirstSnapshotMatching
+  :: MonadUnliftIO m => (Snapshot -> Bool) -> m (Maybe Snapshot)
+getFirstSnapshotMatching p = go 0 1
+ where
+  go seenSoFar page = do
+    result <- getSnapshotsPage page
+    case result of
+      Left _ex -> pure Nothing -- TODO: log it
+      Right sp | ms@Just {} <- findSnapshotPage p sp -> pure ms
+      Right sp | sp.totalCount > seenSoFar -> do
+        go (seenSoFar + snapshotPageLength sp) (page + 1)
+      Right {} -> pure Nothing
+
+getSnapshotsPage
+  :: MonadUnliftIO m => Int -> m (Either HttpException SnapshotPage)
+getSnapshotsPage page = try $ do
+  req <-
+    liftIO
+      $ parseRequestThrow
+      $ "http://www.stackage.org/snapshots?page="
+      <> show page
+  resp <- httpJSON req
+  pure $ getResponseBody resp

--- a/src/SLED/StackageResolver.hs
+++ b/src/SLED/StackageResolver.hs
@@ -1,10 +1,55 @@
 module SLED.StackageResolver
-  ( StackageResolver (..)
+  ( StackageResolver
+  , stackageResolverSameSeries
+  , stackageResolverToText
+  , stackageResolverFromText
+  , readStackageResolver
   ) where
 
 import SLED.Prelude
 
-newtype StackageResolver = StackageResolver
-  { unwrap :: Text
-  }
-  deriving newtype (Eq, Ord, Show, FromJSON, ToJSON)
+import Data.Aeson (withText)
+import SLED.Parse
+
+data StackageResolver
+  = Nightly Text
+  | LTS Nat Nat
+  | Other Text
+  deriving stock (Eq, Ord, Show)
+
+instance FromJSON StackageResolver where
+  parseJSON = withText "StackageResolver" $ pure . stackageResolverFromText
+
+instance ToJSON StackageResolver where
+  toJSON = toJSON . stackageResolverToText
+  toEncoding = toEncoding . stackageResolverToText
+
+stackageResolverSameSeries :: StackageResolver -> StackageResolver -> Bool
+stackageResolverSameSeries =
+  curry $ \case
+    (Nightly {}, Nightly {}) -> True
+    (LTS {}, LTS {}) -> True
+    _ -> False
+
+stackageResolverToText :: StackageResolver -> Text
+stackageResolverToText = \case
+  Nightly x -> "nightly-" <> x
+  LTS major minor -> "lts-" <> pack (show major) <> "." <> pack (show minor)
+  Other x -> x
+
+stackageResolverFromText :: Text -> StackageResolver
+stackageResolverFromText x = parseOr (parseNightly <|> parseLTS) (Other x) x
+
+parseNightly :: ReadP StackageResolver
+parseNightly = do
+  suffix <- string "nightly-" *> many1 anyChar
+  pure $ Nightly $ pack suffix
+
+parseLTS :: ReadP StackageResolver
+parseLTS =
+  LTS
+    <$> (string "lts-" *> nat)
+    <*> (char '.' *> nat)
+
+readStackageResolver :: String -> StackageResolver
+readStackageResolver = stackageResolverFromText . pack

--- a/src/SLED/Suggestion.hs
+++ b/src/SLED/Suggestion.hs
@@ -6,41 +6,43 @@ module SLED.Suggestion
 
 import SLED.Prelude
 
-import SLED.ExtraDep
 import SLED.GitExtraDep
 import SLED.HackageExtraDep
 import SLED.Version
 
-data Suggestion = Suggestion
-  { target :: ExtraDep
-  , action :: SuggestionAction
+data Suggestion t = Suggestion
+  { target :: t
+  , action :: SuggestionAction t
   }
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON)
 
-data SuggestionAction
+data SuggestionAction t
   = Remove
   | UpdateGitCommit CommitSHA
   | UpdateHackageVersion Version
   | ReplaceGitWithHackage HackageExtraDep
+  | ReplaceWith t
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON)
 
-instance Semigroup SuggestionAction where
+instance Semigroup (SuggestionAction t) where
   -- No use doing other changes if we're going to remove a thing
   a@Remove <> _ = a
   _ <> b@Remove = b
   -- No use updating a commit if we're going to replace it
   a@ReplaceGitWithHackage {} <> UpdateGitCommit {} = a
   UpdateGitCommit {} <> b@ReplaceGitWithHackage {} = b
+  ReplaceWith {} <> b@ReplaceWith {} = b -- "later" replacement wins
   -- Other combinations are not possible (e.g. you could never suggestion a
   -- hackage version update and a git commit update on the same dep), but we
   -- can't show that in types. We'll just make the catch-all use Last semantics.
   _ <> b = b
 
-suggestionActionDescription :: SuggestionAction -> Text
+suggestionActionDescription :: SuggestionAction t -> Text
 suggestionActionDescription = \case
   Remove {} -> "This version (or newer) is in your Stackage resolver"
   UpdateGitCommit {} -> "Newer commits exist on the default branch"
   UpdateHackageVersion {} -> "A newer version is available"
   ReplaceGitWithHackage {} -> "A version on Hackage exists for this commit (or newer)"
+  ReplaceWith {} -> "A newer version is available"

--- a/src/SLED/Suggestion/Format.hs
+++ b/src/SLED/Suggestion/Format.hs
@@ -13,6 +13,7 @@ import Data.Aeson (encode)
 import SLED.Suggestion
 import SLED.Suggestion.Format.GHA
 import SLED.Suggestion.Format.TTY
+import SLED.Suggestion.Format.Target
 
 data Format
   = FormatJSON
@@ -36,13 +37,14 @@ defaultFormat :: Format
 defaultFormat = FormatTTY
 
 formatSuggestion
-  :: FilePath
+  :: (IsTarget t, ToJSON t)
+  => FilePath
   -- ^ Current directory
   -> ByteString
   -- ^ Full content of file being linted
   -> Colors
   -> Format
-  -> Marked Suggestion
+  -> Marked (Suggestion t)
   -> Text
 formatSuggestion cwd bs colors = \case
   FormatJSON -> decodeUtf8 . encode

--- a/src/SLED/Suggestion/Format/Action.hs
+++ b/src/SLED/Suggestion/Format/Action.hs
@@ -2,57 +2,43 @@
 
 module SLED.Suggestion.Format.Action
   ( formatAction
-  , formatExtraDep
   ) where
 
 import SLED.Prelude
 
 import Blammo.Logging.Colors
-import qualified Data.Text as T
-import SLED.ExtraDep
 import SLED.GitExtraDep
-import SLED.HackageExtraDep
-import SLED.PackageName
 import SLED.Suggestion
+import SLED.Suggestion.Format.Target
 import SLED.Version
 
-formatAction :: Colors -> ExtraDep -> SuggestionAction -> Text
+formatAction :: IsTarget t => Colors -> t -> SuggestionAction t -> Text
 formatAction Colors {..} target = \case
   Remove ->
     green "Remove"
       <> " "
-      <> magenta (formatExtraDep target)
+      <> magenta (formatTarget target)
   UpdateGitCommit sha ->
     yellow "Update"
       <> " "
-      <> magenta (formatExtraDep target)
+      <> magenta (formatTarget target)
       <> " to "
       <> cyan sha.unwrap
   UpdateHackageVersion version ->
     yellow "Update"
       <> " "
-      <> magenta (formatExtraDep target)
+      <> magenta (formatTarget target)
       <> " to "
       <> cyan (pack $ showVersion version)
   ReplaceGitWithHackage hed ->
     yellow "Replace"
       <> " "
-      <> magenta (formatExtraDep target)
+      <> magenta (formatTarget target)
       <> " with "
-      <> cyan (formatHackageExtraDep hed)
-
-formatExtraDep :: ExtraDep -> Text
-formatExtraDep = \case
-  Hackage hed -> formatHackageExtraDep hed
-  Git ged -> formatGitExtraDep ged
-  Other {} -> "<unknown>"
-
-formatHackageExtraDep :: HackageExtraDep -> Text
-formatHackageExtraDep hed =
-  hed.package.unwrap <> maybe "" (("-" <>) . pack . showVersion) hed.version
-
-formatGitExtraDep :: GitExtraDep -> Text
-formatGitExtraDep ged =
-  repositoryBase ged.repository
-    <> "@"
-    <> T.take 7 (markedItem ged.commit).unwrap
+      <> cyan (formatTarget hed)
+  ReplaceWith other ->
+    yellow "Replace"
+      <> " "
+      <> magenta (formatTarget target)
+      <> " with "
+      <> cyan (formatTarget other)

--- a/src/SLED/Suggestion/Format/GHA.hs
+++ b/src/SLED/Suggestion/Format/GHA.hs
@@ -8,18 +8,19 @@ import Blammo.Logging.Colors
 import qualified Data.Text as T
 import SLED.Suggestion
 import SLED.Suggestion.Format.Action
+import SLED.Suggestion.Format.Target
 
 -- | Format a suggestion to create an annotation in GitHub Actions
 --
 -- @
 -- ::error file={name},line={line},endLine={endLine},title={title}::{message}
 -- @
-formatSuggestionGHA :: Marked Suggestion -> Text
+formatSuggestionGHA :: IsTarget t => Marked (Suggestion t) -> Text
 formatSuggestionGHA m =
   "::error "
     <> T.intercalate "," attrs
     <> "::"
-    <> formatExtraDep s.target
+    <> formatTarget s.target
     <> ": "
     <> suggestionActionDescription s.action
  where

--- a/src/SLED/Suggestion/Format/TTY.hs
+++ b/src/SLED/Suggestion/Format/TTY.hs
@@ -11,14 +11,13 @@ import qualified Data.ByteString.Char8 as BS8
 import Data.Char (isSpace)
 import qualified Data.List.NonEmpty.Extra as NE
 import qualified Data.Text as T
-import SLED.ExtraDep
-import SLED.GitExtraDep
 import SLED.Suggestion
 import SLED.Suggestion.Format.Action
+import SLED.Suggestion.Format.Target
 import System.FilePath (pathSeparator)
 
 formatSuggestionTTY
-  :: FilePath -> ByteString -> Colors -> Marked Suggestion -> Text
+  :: IsTarget t => FilePath -> ByteString -> Colors -> Marked (Suggestion t) -> Text
 formatSuggestionTTY cwd bs colors@Colors {..} m =
   T.unlines
     $ [ formatAction colors s.target s.action
@@ -32,11 +31,7 @@ formatSuggestionTTY cwd bs colors@Colors {..} m =
        ]
  where
   s = markedItem m
-
-  -- For updating git commits, mark the commit itself
-  contentMark = case (s.target, s.action) of
-    (Git ged, UpdateGitCommit {}) -> void $ ged.commit
-    _ -> void m
+  contentMark = getTargetMark m
 
 formatMarkedLocation :: Marked a -> Text
 formatMarkedLocation m =

--- a/src/SLED/Suggestion/Format/TTY.hs
+++ b/src/SLED/Suggestion/Format/TTY.hs
@@ -70,7 +70,7 @@ formatMarkedContentIn Colors {..} m bs =
 
   sideBarWidth = length (show @String endLine) + 1
 
-  -- If we find the newline, we want to return thar char after it (+1), if we
+  -- If we find the newline, we want to return the char after it (+1), if we
   -- don't, we want to return the overall start (0).
   startOfStartLine =
     maybe 0 (+ 1)

--- a/src/SLED/Suggestion/Format/TTY.hs
+++ b/src/SLED/Suggestion/Format/TTY.hs
@@ -58,9 +58,9 @@ formatMarkedContentIn Colors {..} m bs =
     concat
       [ [""]
       , T.lines
-          $ slice bs (startOfStartLine + 1) markedStart
+          $ slice bs startOfStartLine markedStart
           <> wrapNonSpace red (slice bs markedStart markedEnd)
-          <> slice bs (markedEnd + 1) endOfEndLine
+          <> slice bs markedEnd endOfEndLine
       , [markerLine]
       ]
 
@@ -70,13 +70,17 @@ formatMarkedContentIn Colors {..} m bs =
 
   sideBarWidth = length (show @String endLine) + 1
 
+  -- If we find the newline, we want to return thar char after it (+1), if we
+  -- don't, we want to return the overall start (0).
   startOfStartLine =
-    fromMaybe 0
+    maybe 0 (+ 1)
       $ find (\n -> BS8.indexMaybe bs n == Just '\n')
       $ reverse [0 .. markedStart]
 
+  -- Again, if we find a newline we want the char after that (+1), otherwise we
+  -- want the last char (or 0 if it's empty)
   endOfEndLine =
-    fromMaybe (BS8.length bs)
+    maybe (max 0 $ BS8.length bs - 1) (+ 1)
       $ find (\n -> BS8.indexMaybe bs n == Just '\n') [markedEnd ..]
 
   (minColumn, maxColumn) =

--- a/src/SLED/Suggestion/Format/Target.hs
+++ b/src/SLED/Suggestion/Format/Target.hs
@@ -18,7 +18,7 @@ class IsTarget a where
 
   -- | Allows marking parts of a target for specific actions
   --
-  -- We return void since we don't know what type some some item could be, and
+  -- We return void since we don't know what type that part could be, and
   -- at the point we use this we only care about the marks anyway.
   getTargetMark :: Marked (Suggestion a) -> Marked ()
   getTargetMark m = void m

--- a/src/SLED/Suggestion/Format/Target.hs
+++ b/src/SLED/Suggestion/Format/Target.hs
@@ -1,0 +1,49 @@
+module SLED.Suggestion.Format.Target
+  ( IsTarget (..)
+  ) where
+
+import SLED.Prelude
+
+import qualified Data.Text as T
+import SLED.ExtraDep
+import SLED.GitExtraDep
+import SLED.HackageExtraDep
+import SLED.PackageName
+import SLED.StackageResolver
+import SLED.Suggestion
+import SLED.Version
+
+class IsTarget a where
+  formatTarget :: a -> Text
+
+  -- | Allows marking parts of a target for specific actions
+  --
+  -- We return void since we don't know what type some some item could be, and
+  -- at the point we use this we only care about the marks anyway.
+  getTargetMark :: Marked (Suggestion a) -> Marked ()
+  getTargetMark m = void m
+
+instance IsTarget ExtraDep where
+  formatTarget = \case
+    Hackage hed -> formatTarget hed
+    Git ged ->
+      repositoryBase ged.repository
+        <> "@"
+        <> T.take 7 (formatTarget $ markedItem ged.commit)
+    Other {} -> "<unknown>"
+
+  getTargetMark m = case (s.target, s.action) of
+    (Git ged, UpdateGitCommit {}) -> void ged.commit
+    _ -> void m
+   where
+    s = markedItem m
+
+instance IsTarget HackageExtraDep where
+  formatTarget hed =
+    hed.package.unwrap <> maybe "" (("-" <>) . pack . showVersion) hed.version
+
+instance IsTarget CommitSHA where
+  formatTarget = (.unwrap)
+
+instance IsTarget StackageResolver where
+  formatTarget = stackageResolverToText

--- a/stack-lint-extra-deps.cabal
+++ b/stack-lint-extra-deps.cabal
@@ -24,6 +24,7 @@ library
       SLED.Checks.HackageVersion
       SLED.Checks.RedundantGit
       SLED.Checks.RedundantHackage
+      SLED.Checks.StackageResolver
       SLED.ExternalDetails
       SLED.ExtraDep
       SLED.GitDetails
@@ -35,15 +36,18 @@ library
       SLED.Options.Parse
       SLED.Options.Pragma
       SLED.PackageName
+      SLED.Parse
       SLED.Prelude
       SLED.Run
       SLED.Stackage
+      SLED.Stackage.Snapshots
       SLED.StackageResolver
       SLED.StackYaml
       SLED.Suggestion
       SLED.Suggestion.Format
       SLED.Suggestion.Format.Action
       SLED.Suggestion.Format.GHA
+      SLED.Suggestion.Format.Target
       SLED.Suggestion.Format.TTY
       SLED.Version
   other-modules:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,3 @@
 resolver: lts-22.31
-packages:
-  - .
 extra-deps:
-  - github: pbrisbin/yaml-marked
-    commit: 8fe21f6cf13b78f14c0fa41c84456b5dd32bd098
+  - yaml-marked-0.1.0.0

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,16 +5,12 @@
 
 packages:
 - completed:
-    name: yaml-marked
+    hackage: yaml-marked-0.1.0.0@sha256:6390773525f376e881328e95c98a8e38c4e9c188a02f610d23b5aa2eea35500e,5598
     pantry-tree:
-      sha256: 280a8d711fdf09671cc7024bfa696da700ad11034b3433fb700cbe29a8e05ad4
-      size: 1401
-    sha256: 0d0767cb3038809595f1563f607f6b2198c82567a7e66d10bb4e13cbc67e96d0
-    size: 16181
-    url: https://github.com/pbrisbin/yaml-marked/archive/8fe21f6cf13b78f14c0fa41c84456b5dd32bd098.tar.gz
-    version: 0.0.0.0
+      sha256: 27af7104a559e210f927b67f8ebafa768e6125ca08e3d079fcaff95edc7360d6
+      size: 1167
   original:
-    url: https://github.com/pbrisbin/yaml-marked/archive/8fe21f6cf13b78f14c0fa41c84456b5dd32bd098.tar.gz
+    hackage: yaml-marked-0.1.0.0
 snapshots:
 - completed:
     sha256: acaab6ca693211938d1542abcb1c83a2f298b9f6b571854a9d38febe39b6408e

--- a/test/SLED/Checks/HackageSpec.hs
+++ b/test/SLED/Checks/HackageSpec.hs
@@ -151,11 +151,11 @@ spec = do
         `shouldReturn` Nothing
 
 hackageVersions
-  :: [String]
+  :: [Text]
   -- ^ Normal
-  -> [String]
+  -> [Text]
   -- ^ Unpreferred
-  -> [String]
+  -> [Text]
   -- ^ Deprecated
   -> HackageVersions
 hackageVersions n u d =
@@ -166,9 +166,9 @@ hackageVersions n u d =
     }
 
 stackageVersions
-  :: String
+  :: Text
   -- ^ On-page
-  -> String
+  -> Text
   -- ^ On-Hackage
   -> StackageVersions
 stackageVersions p h =

--- a/test/SLED/Options/PragmaSpec.hs
+++ b/test/SLED/Options/PragmaSpec.hs
@@ -82,10 +82,9 @@ spec = do
             , "\n"
             , "\nUsage: stack-lint-extra-deps [-p|--path PATH] [-r|--resolver RESOLVER] "
             , "\n                             [-f|--format tty|gha|json] [--exclude PATTERN] "
-            , "\n                             [--checks CHECKS] [-n|--no-exit] [PATTERN] "
-            , "\n                             [--version]"
-            , "\n"
-            , "\n  stack lint-extra-deps (sled)"
+            , "\n                             [-R|--no-check-resolver] [--checks CHECKS] "
+            , "\n                             [-n|--no-exit] [PATTERN] [--version]"
+            , "\n\n  stack lint-extra-deps (sled)"
             ]
 
       errs `shouldBe` [expectedErr]


### PR DESCRIPTION
There are a few commits, this is the main one:

### [Emit suggestion on out of date resolver](https://github.com/freckle/stack-lint-extra-deps/pull/39/commits/6d075de218fba38557d4737ecdb213ebbafb3160)
[6d075de](https://github.com/freckle/stack-lint-extra-deps/pull/39/commits/6d075de218fba38557d4737ecdb213ebbafb3160)

This required refactoring `Suggestion` and `SuggestionAction` to be
polymorphic in what the suggestion is targeting, along with an
`IsTarget` class to collect shared behaviors against targets, such as
how to display them or find their marks.

Here's what it looks like,

![](https://files.pbrisbin.com/screenshots/screenshot.37071.png)