### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,10 @@ jobs:
       - id: stack
         uses: freckle/stack-action@v5
         with:
-          build-arguments: >-
+          stack-build-arguments: >-
             --local-bin-path ./dist/stack-lint-extra-deps
       - run: |
+          ./dist/stack-lint-extra-deps/stack-lint-extra-deps --version
           tar -C dist -czf ./stack-lint-extra-deps-${{ matrix.suffix }}.tar.gz ./stack-lint-extra-deps
       - uses: freckle/action-gh-release@v2
         with:


### PR DESCRIPTION
I used the wrong input name.

The build still ran, but would not put the binary in the correct place
and we would've shipped and empty archive. So as part of fixing this, I
added that `--version` so that we will instead fail if a mistake that
like that happens again (or my fix is still incorrect).
