### PR TITLE
Decode HackageExtraDep with Data.Yaml.Marked

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -99,3 +99,4 @@ tests:
       - hspec
       - stack-lint-extra-deps
       - text
+      - yaml-marked

--- a/src/SLED/Checks/HackageVersion.hs
+++ b/src/SLED/Checks/HackageVersion.hs
@@ -12,5 +12,5 @@ checkHackageVersion = Check $ \ed extraDep -> do
   Hackage hed <- pure extraDep
   hv <- ed.hackageVersions
   released <- headMaybe hv.normal
-  current <- defaultRevision hv.normal <$> hed.version
+  let current = defaultRevision hv.normal $ markedItem $ hed.version
   UpdateHackageVersion released <$ guard (released > current)

--- a/src/SLED/Checks/RedundantGit.hs
+++ b/src/SLED/Checks/RedundantGit.hs
@@ -21,7 +21,7 @@ checkRedundantGit = Check $ \ed extraDep -> do
       ReplaceGitWithHackage
         HackageExtraDep
           { package = PackageName $ repositoryBaseName ged.repository
-          , version = Just v
+          , version = markAtZero v -- this mark is ignored
           }
 
     -- Attempt to suggest a version tag that exists on Hackage
@@ -37,3 +37,12 @@ checkRedundantGit = Check $ \ed extraDep -> do
       pure $ replaceGitWithHackage version
 
   suggestHackage <|> suggestGit
+
+markAtZero :: a -> Marked a
+markAtZero a =
+  Marked
+    { markedItem = a
+    , markedPath = "<input>"
+    , markedLocationStart = Location 0 0 0
+    , markedLocationEnd = Location 0 0 0
+    }

--- a/src/SLED/Checks/RedundantHackage.hs
+++ b/src/SLED/Checks/RedundantHackage.hs
@@ -11,6 +11,7 @@ checkRedundantHackage :: Check
 checkRedundantHackage = Check $ \ed extraDep -> do
   Hackage hed <- pure extraDep
   sv <- ed.stackageVersions
-  let hvs = maybe [] (.normal) ed.hackageVersions
-  current <- defaultRevision hvs <$> hed.version
+  let
+    hvs = maybe [] (.normal) ed.hackageVersions
+    current = defaultRevision hvs $ markedItem hed.version
   Remove <$ guard (sv.onPage >= current)

--- a/src/SLED/ExtraDep.hs
+++ b/src/SLED/ExtraDep.hs
@@ -7,7 +7,6 @@ module SLED.ExtraDep
 import SLED.Prelude
 
 import Control.Error.Util (hush)
-import Data.Yaml.Marked.Parse
 import Data.Yaml.Marked.Value
 import SLED.GitExtraDep
 import SLED.HackageExtraDep
@@ -15,7 +14,7 @@ import SLED.PackageName
 import System.FilePath.Glob
 
 data ExtraDep
-  = -- | @{package}(-{version})(@{checksum})
+  = -- | @{package}-{version(\@rev:{number})}@
     Hackage HackageExtraDep
   | -- | @{ git: {repository}, commit: {commit} }@
     Git GitExtraDep
@@ -30,7 +29,7 @@ decodeExtraDep mv =
     $ fromMaybe (Other () <$ mv)
     $ asum
       [ hush (Git <$$> decodeGitExtraDep mv)
-      , hush (Hackage <$$> json mv)
+      , hush (Hackage <$$> decodeHackageExtraDep mv)
       ]
 
 matchPattern :: Pattern -> ExtraDep -> Bool

--- a/src/SLED/Parse.hs
+++ b/src/SLED/Parse.hs
@@ -2,6 +2,7 @@ module SLED.Parse
   ( ReadP
   , parse
   , parseOr
+  , parseErr
   , string
   , char
   , anyChar
@@ -13,6 +14,7 @@ where
 
 import SLED.Prelude
 
+import Control.Error.Util (note)
 import Data.Char (isDigit, isHexDigit)
 import qualified Data.List.NonEmpty as NE
 import Text.ParserCombinators.ReadP
@@ -23,6 +25,9 @@ parse p = fmap (fst . NE.last) . nonEmpty . readP_to_S (p <* eof) . unpack
 
 parseOr :: ReadP a -> a -> Text -> a
 parseOr p def = maybe def (fst . NE.last) . nonEmpty . readP_to_S (p <* eof) . unpack
+
+parseErr :: (Text -> String) -> ReadP a -> Text -> Either String a
+parseErr mkMessage p t = note (mkMessage t) $ parse p t
 
 nat :: ReadP Natural
 nat = fmap Unsafe.read $ many1 $ satisfy isDigit

--- a/src/SLED/Suggestion/Format/Target.hs
+++ b/src/SLED/Suggestion/Format/Target.hs
@@ -33,6 +33,7 @@ instance IsTarget ExtraDep where
     Other {} -> "<unknown>"
 
   getTargetMark m = case (s.target, s.action) of
+    (Hackage hed, UpdateHackageVersion {}) -> void hed.version
     (Git ged, UpdateGitCommit {}) -> void ged.commit
     _ -> void m
    where
@@ -40,10 +41,13 @@ instance IsTarget ExtraDep where
 
 instance IsTarget HackageExtraDep where
   formatTarget hed =
-    hed.package.unwrap <> maybe "" (("-" <>) . pack . showVersion) hed.version
+    hed.package.unwrap <> "-" <> pack (showVersion $ markedItem hed.version)
 
 instance IsTarget CommitSHA where
   formatTarget = (.unwrap)
+
+instance IsTarget Version where
+  formatTarget = pack . showVersion
 
 instance IsTarget StackageResolver where
   formatTarget = stackageResolverToText

--- a/src/SLED/Version.hs
+++ b/src/SLED/Version.hs
@@ -2,6 +2,7 @@ module SLED.Version
   ( Version
   , defaultRevision
   , parseVersion
+  , versionParser
   , showVersion
   ) where
 
@@ -35,9 +36,11 @@ eqOnVersion :: Version -> Version -> Bool
 eqOnVersion = (==) `on` (.version)
 
 parseVersion :: Text -> Maybe Version
-parseVersion =
-  parse
-    $ parseWithRevision
+parseVersion = parse versionParser
+
+versionParser :: ReadP Version
+versionParser =
+  parseWithRevision
     <|> parseWithChecksum
     <|> parseSimple
 

--- a/stack-lint-extra-deps.cabal
+++ b/stack-lint-extra-deps.cabal
@@ -156,6 +156,7 @@ test-suite hspec
   other-modules:
       SLED.Checks.GitSpec
       SLED.Checks.HackageSpec
+      SLED.HackageExtraDepSpec
       SLED.HackageSpec
       SLED.Options.PragmaSpec
       SLED.RunSpec
@@ -188,4 +189,5 @@ test-suite hspec
     , hspec
     , stack-lint-extra-deps
     , text
+    , yaml-marked
   default-language: Haskell2010

--- a/test/SLED/Checks/GitSpec.hs
+++ b/test/SLED/Checks/GitSpec.hs
@@ -9,7 +9,6 @@ import SLED.Prelude
 import qualified Data.List.NonEmpty as NE
 import SLED.Suggestion
 import SLED.Test
-import SLED.Version
 
 spec :: Spec
 spec = do
@@ -60,6 +59,6 @@ spec = do
           ( ReplaceGitWithHackage
               $ HackageExtraDep
                 { package = PackageName "foo"
-                , version = parseVersion "1.0.2"
+                , version = markAtZero $ unsafeVersion "1.0.2"
                 }
           )

--- a/test/SLED/Checks/HackageSpec.hs
+++ b/test/SLED/Checks/HackageSpec.hs
@@ -26,7 +26,7 @@ spec = do
         mempty
         HackageExtraDep
           { package = package
-          , version = parseVersion "1.0.1.1"
+          , version = markAtZero $ unsafeVersion "1.0.1.1"
           }
         `shouldReturn` Just (UpdateHackageVersion version)
 
@@ -40,7 +40,7 @@ spec = do
         mempty
         HackageExtraDep
           { package = package
-          , version = parseVersion "1.0.1.1"
+          , version = markAtZero $ unsafeVersion "1.0.1.1"
           }
         `shouldReturn` Nothing
 
@@ -55,7 +55,7 @@ spec = do
         hed =
           HackageExtraDep
             { package = package
-            , version = parseVersion "1.0.1.1"
+            , version = markAtZero $ unsafeVersion "1.0.1.1"
             }
 
       runHackageChecks mempty mockStackage hed
@@ -74,7 +74,7 @@ spec = do
         mockStackage
         HackageExtraDep
           { package = package
-          , version = Just $ unsafeVersion "1.0.1.1"
+          , version = markAtZero $ unsafeVersion "1.0.1.1"
           }
         `shouldReturn` Just Remove
 
@@ -91,7 +91,7 @@ spec = do
         mockStackage
         HackageExtraDep
           { package = package
-          , version = Just $ unsafeVersion "1.0.1.1"
+          , version = markAtZero $ unsafeVersion "1.0.1.1"
           }
         `shouldReturn` Nothing
 
@@ -109,7 +109,7 @@ spec = do
         mockStackage
         HackageExtraDep
           { package = package
-          , version = Just $ unsafeVersion "0.3.5"
+          , version = markAtZero $ unsafeVersion "0.3.5"
           }
         `shouldReturn` Nothing
 
@@ -128,7 +128,7 @@ spec = do
         mockStackage
         HackageExtraDep
           { package = package
-          , version = Just version
+          , version = markAtZero version
           }
         `shouldReturn` Nothing
 
@@ -146,7 +146,7 @@ spec = do
         mockStackage
         HackageExtraDep
           { package = package
-          , version = Just $ unsafeVersion "0.3.5@rev:11"
+          , version = markAtZero $ unsafeVersion "0.3.5@rev:11"
           }
         `shouldReturn` Nothing
 

--- a/test/SLED/HackageExtraDepSpec.hs
+++ b/test/SLED/HackageExtraDepSpec.hs
@@ -1,0 +1,89 @@
+module SLED.HackageExtraDepSpec
+  ( spec
+  ) where
+
+import SLED.Prelude
+
+import Data.Yaml.Marked.Decode
+import Data.Yaml.Marked.Parse
+import SLED.HackageExtraDep
+import SLED.Test
+
+spec :: Spec
+spec = do
+  describe "decodeHackageExtraDep" $ do
+    describe "successful decoding" $ do
+      it "simple" $ do
+        mdeps <- tryDecode "- foo-0.1.0.0\n"
+        --                        ^^^^^^^^
+        --                  01234567890123
+        --                            1111
+        map markedItem (markedItem mdeps)
+          `shouldBe` [ HackageExtraDep
+                        { package = PackageName "foo"
+                        , version =
+                            Marked
+                              { markedItem = unsafeVersion "0.1.0.0"
+                              , markedPath = "<input>"
+                              , markedLocationStart = Location 6 0 6
+                              , markedLocationEnd = Location 13 0 13
+                              }
+                        }
+                     ]
+
+      it "multi-hyphenated" $ do
+        mdeps <- tryDecode "- optparse-applicative-0.1.0.0\n"
+        --                                         ^^^^^^^^
+        --                  0123456789012345678901234567890
+        --                            111111111122222222223
+        map markedItem (markedItem mdeps)
+          `shouldBe` [ HackageExtraDep
+                        { package = PackageName "optparse-applicative"
+                        , version =
+                            Marked
+                              { markedItem = unsafeVersion "0.1.0.0"
+                              , markedPath = "<input>"
+                              , markedLocationStart = Location 23 0 23
+                              , markedLocationEnd = Location 30 0 30
+                              }
+                        }
+                     ]
+
+      it "with revision" $ do
+        mdeps <- tryDecode "- foo-0.1.0.0@rev:5\n"
+        --                        ^^^^^^^^^^^^^^
+        --                  01234567890123456789
+        --                            1111111111
+        map markedItem (markedItem mdeps)
+          `shouldBe` [ HackageExtraDep
+                        { package = PackageName "foo"
+                        , version =
+                            Marked
+                              { markedItem = unsafeVersion "0.1.0.0@rev:5"
+                              , markedPath = "<input>"
+                              , markedLocationStart = Location 6 0 6
+                              , markedLocationEnd = Location 19 0 19
+                              }
+                        }
+                     ]
+
+      it "with revision" $ do
+        mdeps <- tryDecode "- foo-0.1.0.0@sha256:ffffff,100\n"
+        --                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+        --                  01234567890123456789012345678901
+        --                            1111111111222222222233
+        map markedItem (markedItem mdeps)
+          `shouldBe` [ HackageExtraDep
+                        { package = PackageName "foo"
+                        , version =
+                            Marked
+                              { markedItem = unsafeVersion "0.1.0.0@sha256:ffffff,100"
+                              , markedPath = "<input>"
+                              , markedLocationStart = Location 6 0 6
+                              , markedLocationEnd = Location 31 0 31
+                              }
+                        }
+                     ]
+
+tryDecode :: ByteString -> IO (Marked [Marked HackageExtraDep])
+tryDecode = decodeThrow (array decodeHackageExtraDep) "<input>"

--- a/test/SLED/RunSpec.hs
+++ b/test/SLED/RunSpec.hs
@@ -6,7 +6,6 @@ import SLED.Prelude
 
 import SLED.Run
 import SLED.Test
-import SLED.Version
 
 spec :: Spec
 spec = do
@@ -57,7 +56,7 @@ freckleApp1011 :: HackageExtraDep
 freckleApp1011 =
   HackageExtraDep
     { package = PackageName "freckle-app"
-    , version = parseVersion "1.0.1.1"
+    , version = markAtZero $ unsafeVersion "1.0.1.1"
     }
 
 yesodFlowRoutesGitHub :: GitExtraDep


### PR DESCRIPTION
Rather than treating it as opaque JSON. Additionally, leverage our
`ReadP` helpers to actually implement a real parse instead of the
existing textual splitting and reading.

This allows us to store a `Marked Version`, which is consistent with how
we mark only the `commit` of a git extra-dep.

It means our errors will now look like this:

    Update hspec-2.8.3 to 2.11.10
      ├ /home/patrick/code/freckle/stack-lint-extra-deps/test/examples/lts-18.18.yaml:14:5
      │    |
      │ 14 |  - hspec-2.8.3
      │    |          ^^^^^
      │
      └ A newer version is available

Instead of this:

    Update hspec-2.8.3 to 2.11.10
      ├ /home/patrick/code/freckle/stack-lint-extra-deps/test/examples/lts-18.18.yaml:14:5
      │    |
      │ 14 |  - hspec-2.8.3
      │    |  ^^^^^^^^^^^^^
      │
      └ A newer version is available

Marking specifically the version will also be required when we implement
auto-fix as a replacement of just the version bit.
