### PR TITLE
Implement --fix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,10 @@ runs:
               --retry 5 \
               --retry-delay 0 \
               --retry-max-time 30 \
-              -sSf https://api.github.com/repos/freckle/stack-lint-extra-deps/releases |
+              --fail-with-body \
+              --show-error \
+              --silent https://api.github.com/repos/freckle/stack-lint-extra-deps/releases |
+              tee /dev/stderr |
               jq '.[] | select(.draft|not) | select(.prerelease|not) | .tag_name' --raw-output |
               head -n 1
           )

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,12 @@ inputs:
       to be installed and on PATH already.
     required: false
     default: false
+  github-token:
+    description: |
+      GitHub token for authenticating with GitHub API (to determine release
+      version). Authentication is not required, but can help avoid rate-limit
+      errors.
+    default: ${{ github.token }}
 
 outputs: {}
 
@@ -27,19 +33,19 @@ runs:
     - id: prep
       if: ${{ inputs.no-install != 'true' }}
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
         version=${{ inputs.version }}
 
         if [[ -z "$version" ]]; then
           read -r version < <(
             curl \
-              --max-time 10 \
-              --retry 5 \
-              --retry-delay 0 \
-              --retry-max-time 30 \
-              --fail-with-body \
+              --silent \
               --show-error \
-              --silent https://api.github.com/repos/freckle/stack-lint-extra-deps/releases |
+              --fail-with-body \
+              --header "authentication: token $GITHUB_TOKEN }}" \
+              https://api.github.com/repos/freckle/stack-lint-extra-deps/releases |
               tee /dev/stderr |
               jq '.[] | select(.draft|not) | select(.prerelease|not) | .tag_name' --raw-output |
               head -n 1

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,12 @@ runs:
 
         if [[ -z "$version" ]]; then
           read -r version < <(
-            curl --silent https://api.github.com/repos/freckle/stack-lint-extra-deps/releases |
+            curl \
+              --max-time 10 \
+              --retry 5 \
+              --retry-delay 0 \
+              --retry-max-time 30 \
+              -sSf https://api.github.com/repos/freckle/stack-lint-extra-deps/releases |
               jq '.[] | select(.draft|not) | select(.prerelease|not) | .tag_name' --raw-output |
               head -n 1
           )

--- a/action.yml
+++ b/action.yml
@@ -33,27 +33,21 @@ runs:
     - id: prep
       if: ${{ inputs.no-install != 'true' }}
       shell: bash
-      env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
         version=${{ inputs.version }}
 
         if [[ -z "$version" ]]; then
           read -r version < <(
-            curl \
-              --silent \
-              --show-error \
-              --fail-with-body \
-              --header "authentication: token $GITHUB_TOKEN }}" \
-              https://api.github.com/repos/freckle/stack-lint-extra-deps/releases |
-              tee /dev/stderr |
-              jq '.[] | select(.draft|not) | select(.prerelease|not) | .tag_name' --raw-output |
+            gh api '/repos/freckle/stack-lint-extra-deps/releases' \
+              --jq '.[] | select(.draft|not) | select(.prerelease|not) | .tag_name' |
               head -n 1
           )
         fi
 
         echo "Installing stack-lint-extra-deps $version"
         echo "version=$version" >> "$GITHUB_OUTPUT"
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
 
     - if: ${{ inputs.no-install != 'true' }}
       uses: pbrisbin/setup-tool-action@v2

--- a/package.yaml
+++ b/package.yaml
@@ -45,8 +45,8 @@ library:
     - Glob
     - aeson
     - bytestring
-    - conduit
     - containers
+    - dlist
     - errors
     - exceptions
     - extra
@@ -57,6 +57,7 @@ library:
     - lens
     - optparse-applicative
     - relude
+    - safe-exceptions
     - semigroups
     - shellwords
     - text

--- a/src/SLED/Context.hs
+++ b/src/SLED/Context.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RankNTypes #-}
+
+module SLED.Context
+  ( Context
+  , execContextT
+  , seenL
+  , contentsL
+  , whenUnseen
+  , untilNoneSeen
+  , sequenceFirstSeen
+  , rewriteContents
+  ) where
+
+import SLED.Prelude hiding ((.=))
+
+import Control.Lens (views, (.=))
+import Data.DList (DList)
+
+data Context = Context
+  { seen :: DList (Marked Bool)
+  -- ^ Tracking 'Suggestion's made so far, so we don't re-make them
+  --
+  -- The 'Bool' indicates if the suggestion was auto-fixed. We can't hold the
+  -- target itself because its type will change throughout.
+  , contents :: ByteString
+  -- ^ @stack.yaml@ contents, updated with any auto-fixes
+  }
+
+execContextT :: Monad m => ByteString -> StateT Context m a -> m Context
+execContextT contents f = execStateT f $ Context {seen = mempty, contents}
+
+seenL :: Lens' Context (DList (Marked Bool))
+seenL = lens (.seen) $ \x y -> x {seen = y}
+
+contentsL :: Lens' Context ByteString
+contentsL = lens (.contents) $ \x y -> x {contents = y}
+
+-- | Run an action unless the item is already present in 'seen'
+whenUnseen
+  :: MonadState Context m => (Marked a -> m ()) -> Marked a -> m ()
+whenUnseen act m = do
+  unseen <- gets $ views seenL $ \ms -> void m `notElem` fmap void ms
+  when unseen $ act m
+
+-- | Repeat an action until it no longer adds 'seen' values
+untilNoneSeen :: MonadState Context m => m () -> m ()
+untilNoneSeen act = do
+  new <- runAndCheckSeen act
+  when new $ untilNoneSeen act
+
+-- | Run a list of actions stopping after any new value is added to 'seen'
+sequenceFirstSeen :: MonadState Context m => [m ()] -> m ()
+sequenceFirstSeen = \case
+  [] -> pure ()
+  f : fs -> do
+    new <- runAndCheckSeen f
+    unless new $ sequenceFirstSeen fs
+
+runAndCheckSeen :: MonadState Context m => m () -> m Bool
+runAndCheckSeen act = do
+  before <- gets $ views seenL length
+  act
+  gets $ views seenL $ (> before) . length
+
+rewriteContents :: MonadState Context m => (ByteString -> m ByteString) -> m ()
+rewriteContents = overM contentsL
+
+overM :: MonadState s m => Lens' s b -> (b -> m b) -> m ()
+overM l f = do
+  x <- gets $ view l
+  void $ (l .=) =<< f x

--- a/src/SLED/Marked/Line.hs
+++ b/src/SLED/Marked/Line.hs
@@ -1,0 +1,40 @@
+-- | Helpers for dealing with 'Marked' lines
+module SLED.Marked.Line
+  ( startOfStartLine
+  , endOfEndLine
+  , markedStart
+  , markedEnd
+  ) where
+
+import SLED.Prelude
+
+import qualified Data.ByteString.Char8 as BS8
+import Numeric.Natural (minusNaturalMaybe)
+
+-- | Locate the start index of the start of a mark's line
+--
+-- This will be the index of the character /after/ the nearest newline
+-- backwards. This will return zero if there is no newline, or if the bytestring
+-- is empty.
+startOfStartLine :: ByteString -> Marked a -> Natural
+startOfStartLine bs m = maybe 0 (+ 1) $ findNewline bs $ reverse [0 .. markedStart m]
+
+-- | Locate the end index of the end of a mark's line
+--
+-- This will be the index /of/ the nearest newline forwards. This will return
+-- the last index in the bytestring if there is no newline, and will return 0 if
+-- the bytestring is empty.
+endOfEndLine :: ByteString -> Marked a -> Natural
+endOfEndLine bs m = fromMaybe endIdx $ findNewline bs [markedEnd m .. endIdx]
+ where
+  endIdx :: Natural
+  endIdx = fromMaybe 0 $ fromIntegral (BS8.length bs) `minusNaturalMaybe` 1
+
+findNewline :: ByteString -> [Natural] -> Maybe Natural
+findNewline bs = find (\n -> BS8.indexMaybe bs (fromIntegral n) == Just '\n')
+
+markedStart :: Marked a -> Natural
+markedStart = locationIndex . markedLocationStart
+
+markedEnd :: Marked a -> Natural
+markedEnd = locationIndex . markedLocationEnd

--- a/src/SLED/Options.hs
+++ b/src/SLED/Options.hs
@@ -22,6 +22,7 @@ data Options = Options
   , noCheckResolver :: Any
   , checks :: Maybe ChecksName
   , noExit :: Any
+  , autoFix :: Any
   , filter :: Last Pattern
   , version :: Any
   }
@@ -89,6 +90,13 @@ optionsParser =
               ( short 'n'
                   <> long "no-exit"
                   <> help "Exit successfully, even if suggestions found"
+              )
+        )
+    <*> ( Any
+            <$> switch
+              ( short 'F'
+                  <> long "fix"
+                  <> help "Automatically fix problems"
               )
         )
     <*> ( Last

--- a/src/SLED/Suggestion/Format/Target.hs
+++ b/src/SLED/Suggestion/Format/Target.hs
@@ -1,10 +1,12 @@
 module SLED.Suggestion.Format.Target
   ( IsTarget (..)
+  , replaceMarkedTarget
   ) where
 
 import SLED.Prelude
 
 import qualified Data.Text as T
+import Data.Yaml.Marked.Replace
 import SLED.ExtraDep
 import SLED.GitExtraDep
 import SLED.HackageExtraDep
@@ -51,3 +53,11 @@ instance IsTarget Version where
 
 instance IsTarget StackageResolver where
   formatTarget = stackageResolverToText
+
+replaceMarkedTarget
+  :: (IsTarget a, IsTarget b)
+  => Marked (Suggestion a)
+  -> b
+  -> Replace
+replaceMarkedTarget a =
+  replaceMarked (getTargetMark a) . encodeUtf8 . formatTarget

--- a/stack-lint-extra-deps.cabal
+++ b/stack-lint-extra-deps.cabal
@@ -25,6 +25,7 @@ library
       SLED.Checks.RedundantGit
       SLED.Checks.RedundantHackage
       SLED.Checks.StackageResolver
+      SLED.Context
       SLED.ExternalDetails
       SLED.ExtraDep
       SLED.GitDetails
@@ -75,8 +76,8 @@ library
     , aeson
     , base
     , bytestring
-    , conduit
     , containers
+    , dlist
     , errors
     , exceptions
     , extra
@@ -87,6 +88,7 @@ library
     , lens
     , optparse-applicative
     , relude
+    , safe-exceptions
     , semigroups
     , shellwords
     , text

--- a/stack-lint-extra-deps.cabal
+++ b/stack-lint-extra-deps.cabal
@@ -31,6 +31,7 @@ library
       SLED.GitExtraDep
       SLED.Hackage
       SLED.HackageExtraDep
+      SLED.Marked.Line
       SLED.Options
       SLED.Options.BoundedEnum
       SLED.Options.Parse
@@ -158,6 +159,7 @@ test-suite hspec
       SLED.Checks.HackageSpec
       SLED.HackageExtraDepSpec
       SLED.HackageSpec
+      SLED.Marked.LineSpec
       SLED.Options.PragmaSpec
       SLED.RunSpec
       SLED.StackageSpec

--- a/test/SLED/Marked/LineSpec.hs
+++ b/test/SLED/Marked/LineSpec.hs
@@ -1,0 +1,56 @@
+module SLED.Marked.LineSpec
+  ( spec
+  ) where
+
+import SLED.Prelude
+
+import SLED.Marked.Line
+import SLED.Test
+
+spec :: Spec
+spec = do
+  let
+    exampleBS :: ByteString
+    exampleBS = "this is line one\nthis is line two\nthis is line 3\n"
+  --             01234567890123456 78901234567890123 456789012345678
+  --                       1111111 11122222222223333 333333444444444
+  --             |---------------| |---------------| |-------------|
+  --             0              16 17             33 34           48
+
+  describe "startOfStartLine" $ do
+    it "finds the start of the start line of a mark" $ do
+      startOfStartLine exampleBS (markAt 22 38) `shouldBe` 17
+
+    it "works with content at the start of a line" $ do
+      startOfStartLine exampleBS (markAt 17 22) `shouldBe` 17
+
+    it "works with content at the start overall" $ do
+      startOfStartLine exampleBS (markAt 0 17) `shouldBe` 0
+
+    it "works with empty content" $ do
+      startOfStartLine "" (markAt 0 17) `shouldBe` 0
+
+  describe "endOfEndLine" $ do
+    it "finds the end of the end line of a mark" $ do
+      endOfEndLine exampleBS (markAt 22 38) `shouldBe` 48
+
+    it "works with content at the end of a line" $ do
+      endOfEndLine exampleBS (markAt 22 33) `shouldBe` 33
+
+    it "works with content at the end overall" $ do
+      endOfEndLine exampleBS (markAt 38 48) `shouldBe` 48
+
+    it "works with content outside the end" $ do
+      endOfEndLine exampleBS (markAt 38 49) `shouldBe` 48
+
+    it "works with empty content" $ do
+      endOfEndLine "" (markAt 38 49) `shouldBe` 0
+
+markAt :: Natural -> Natural -> Marked ()
+markAt s e =
+  Marked
+    { markedItem = ()
+    , markedPath = "unused"
+    , markedLocationStart = Location s 0 0 -- line/column unused
+    , markedLocationEnd = Location e 0 0 -- line/column unused
+    }

--- a/test/SLED/Options/PragmaSpec.hs
+++ b/test/SLED/Options/PragmaSpec.hs
@@ -83,7 +83,7 @@ spec = do
             , "\nUsage: stack-lint-extra-deps [-p|--path PATH] [-r|--resolver RESOLVER] "
             , "\n                             [-f|--format tty|gha|json] [--exclude PATTERN] "
             , "\n                             [-R|--no-check-resolver] [--checks CHECKS] "
-            , "\n                             [-n|--no-exit] [PATTERN] [--version]"
+            , "\n                             [-n|--no-exit] [-F|--fix] [PATTERN] [--version]"
             , "\n\n  stack lint-extra-deps (sled)"
             ]
 


### PR DESCRIPTION
The main reason `--fix` has been so elusive, even once `yaml-marked` was
available and `Data.Yaml.Marked.Replace` was ready, is that, as soon as
you replace the content for one fix, that throws off the marks of
anything after it, meaning replacing those would then not do what you
expect.

To address this, I changed the main `runSLED` routine to be a loop of
parsing, suggesting, and perhaps fixing **one suggestion at a time**.

As this loop runs, we maintain the state of the underlying `ByteString`
as fixes are made. If a replacement happens, the next round would parse
from the updated contents and so the suggestions it made would have
accurate marks and be able to make a correct replacement too.

This also required tracking the (marks of) suggestions made already, so
that on each loop (in the case you _weren't_ auto-fixing) didn't
re-suggest the same things every time.

All of this got batched up into a new `Context` type and the routine is
placed in `StateT`. I chose `StateT` (instead of `MonadState`) because
we need to `lift` out to perform actions that require `MonadUnliftIO`.
If I can change that in the future, we could consider `MonadState` and
incorporate `Context` into our existing `AppT`, rather than adding a new
concrete layer.

![](https://files.pbrisbin.com/screenshots/screenshot.665452.png)