### PR TITLE
Fix nix build (ghc 9.8.4)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,6 +2,22 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
+        "lastModified": 1734323986,
+        "narHash": "sha256-m/lh6hYMIWDYHCAsn81CDAiXoT3gmxXI9J987W5tZrE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "394571358ce82dff7411395829aa6a3aad45b907",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-haskell-updates": {
+      "locked": {
         "lastModified": 1734394670,
         "narHash": "sha256-ttW+BaeNbquXRMFbjqTo2D2vOBv95jHRWgD/94yMGw8=",
         "owner": "nixos",
@@ -35,6 +51,7 @@
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
+        "nixpkgs-haskell-updates": "nixpkgs-haskell-updates",
         "pgp-wordlist": "pgp-wordlist",
         "stacklock2nix": "stacklock2nix"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733756863,
-        "narHash": "sha256-gbivEqdl62NnnESKvRiUR+GRhCGrf1mUoNtGl/yYu4k=",
+        "lastModified": 1734394670,
+        "narHash": "sha256-ttW+BaeNbquXRMFbjqTo2D2vOBv95jHRWgD/94yMGw8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "06886d32c517d0e199c0e6d345d54673acc55453",
+        "rev": "873b5ff14545ee502918a74993cfb77b474e2805",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734323986,
-        "narHash": "sha256-m/lh6hYMIWDYHCAsn81CDAiXoT3gmxXI9J987W5tZrE=",
+        "lastModified": 1736200483,
+        "narHash": "sha256-JO+lFN2HsCwSLMUWXHeOad6QUxOuwe9UOAF/iSl1J4I=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "394571358ce82dff7411395829aa6a3aad45b907",
+        "rev": "3f0a8ac25fb674611b98089ca3a5dd6480175751",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "nixpkgs-haskell-updates": {
       "locked": {
-        "lastModified": 1734394670,
-        "narHash": "sha256-ttW+BaeNbquXRMFbjqTo2D2vOBv95jHRWgD/94yMGw8=",
+        "lastModified": 1736295319,
+        "narHash": "sha256-D408QVHL43RPYdPnGhTpBHJs4wVIebbsmh/SAAY0vAE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "873b5ff14545ee502918a74993cfb77b474e2805",
+        "rev": "b6b38bb0649cb8393492949e01b1e331c3a05718",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -72,7 +72,7 @@
           stackYaml = ./stack.yaml;
 
           # GHC version that matches stack.yaml
-          baseHaskellPkgSet = final.haskell.packages.ghc966;
+          baseHaskellPkgSet = final.haskell.packages.ghc984;
 
           # It is necessary to get this using a fetcher that doesn't unpack to
           # preserve hash compatibility among case (in/)sensitive file systems.

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,12 @@
       type = "github";
       owner = "nixos";
       repo = "nixpkgs";
+      ref = "nixos-24.11";
+    };
+    nixpkgs-haskell-updates = {
+      type = "github";
+      owner = "nixos";
+      repo = "nixpkgs";
       ref = "haskell-updates";
     };
     stacklock2nix = {
@@ -23,6 +29,7 @@
     {
       self,
       nixpkgs,
+      nixpkgs-haskell-updates,
       pgp-wordlist,
       stacklock2nix,
     }:
@@ -38,13 +45,10 @@
 
       nixpkgsFor = forAllSystems (
         system:
-        import nixpkgs {
-          inherit system;
-          overlays = [
-            stacklock2nix.overlay
-            self.overlays.default
-          ];
-        }
+        nixpkgs-haskell-updates.legacyPackages.${system}.appendOverlays [
+          stacklock2nix.overlay
+          self.overlays.default
+        ]
       );
     in
     {
@@ -85,7 +89,7 @@
           additionalHaskellPkgSetOverrides =
             hfinal: hprev:
             # Workarounds for issues in tests
-            nixpkgs.lib.genAttrs [
+            nixpkgs-haskell-updates.lib.genAttrs [
               "ansi-wl-pprint"
               "case-insensitive"
               "integer-logarithms"
@@ -94,6 +98,7 @@
               "prettyprinter-compat-ansi-wl-pprint"
               "primitive"
               "quickcheck-instances"
+              "serialise"
               "test-framework"
               "uuid-types"
               "yaml-marked"
@@ -102,7 +107,7 @@
           additionalDevShellNativeBuildInputs = stacklockHaskellPkgSet: [
             final.cabal-install
             final.haskellPackages.fourmolu
-            final.stack
+            nixpkgs.legacyPackages.${final.system}.stack
             final.zlib
           ];
         };

--- a/flake.nix
+++ b/flake.nix
@@ -78,8 +78,8 @@
           # preserve hash compatibility among case (in/)sensitive file systems.
           all-cabal-hashes = final.fetchurl {
             name = "all-cabal-hashes";
-            url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/82b9142173a2d39bc0988dce33d618a892e2e7f1.tar.gz";
-            sha256 = "sha256-mKOc6+wsY0JT7/K64RLg6O7AR8aS/tguX8NZbyLVdks=";
+            url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/090338d05bcc279b2c99f0251943a62ef4e5f8ae.tar.gz";
+            sha256 = "sha256-DFxLXAXAfZjk+LIwezqpnQGo9GgwI6Fpua31aTOWI+I=";
           };
 
           additionalHaskellPkgSetOverrides =

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,5 @@
-resolver: lts-23.0
+resolver: lts-23.1
 extra-deps:
+  - hedgehog-1.4
+  - tasty-quickcheck-0.10.3
   - yaml-marked-0.2.0.1

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,6 +5,20 @@
 
 packages:
 - completed:
+    hackage: hedgehog-1.4@sha256:9860ab34ab3951d9515c71b777d8c9c47610aae7339933e17d26ad9a4afa5618,4754
+    pantry-tree:
+      sha256: 8fd5983d447a5362856d4741d9e19cac8dcab150017c91b0c5acad6472afb0f6
+      size: 2713
+  original:
+    hackage: hedgehog-1.4
+- completed:
+    hackage: tasty-quickcheck-0.10.3@sha256:39154b9444d8d3cd13884b9d9157752af822e03c53542d410ab317f62c0b4f48,1864
+    pantry-tree:
+      sha256: 2155418f7f07743257444e600291372e7fa7733fab9a277c84f6b6d66d631e4c
+      size: 332
+  original:
+    hackage: tasty-quickcheck-0.10.3
+- completed:
     hackage: yaml-marked-0.2.0.1@sha256:e1178ace8a85559abdc61c25ae015f75ad977c3e9516f0f25f46858d34c1b61f,5598
     pantry-tree:
       sha256: 6ce8f2798ab4142658f0a9a500d995a2ddbe66a3cffeb968470030ee22d27c02
@@ -13,7 +27,7 @@ packages:
     hackage: yaml-marked-0.2.0.1
 snapshots:
 - completed:
-    sha256: 9444fadfa30b67a93080254d53872478c087592ad64443e47c546cdcd13149ae
-    size: 678857
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/23/0.yaml
-  original: lts-23.0
+    sha256: 18514ff1ed00330c922bd8d28d88a54670a9849f17eb07dc78391a94d576749d
+    size: 678854
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/23/1.yaml
+  original: lts-23.1


### PR DESCRIPTION
A little fiddling was required on this one.

- Nix builds run the tests by default and I think Stackage doesn't, so Stackage moved some test libraries ahead of what packages in the LTS actually support. We could disables tests on the affected packages but it seemed easier to hold back the test library upgrades in `stack.yaml` instead.
- Stack itself doesn't seem to build on GHC 9.8.4 yet, so modified the dev shell to get the default version of Stack rather than building it with the project's resolver.