### PR TITLE
push all-cabal-hashes out to a json file

### DIFF
--- a/all-cabal-hashes.json
+++ b/all-cabal-hashes.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://github.com/commercialhaskell/all-cabal-hashes/archive/5930c2335a80404908fafcff6d99ef15a3b68aae.tar.gz",
+  "sha256": "1nagkbxy9fwyx46d3cvhq1y3sanxd73hbghfyxp6mf79f21g7xci"
+}

--- a/flake.nix
+++ b/flake.nix
@@ -80,11 +80,12 @@
 
           # It is necessary to get this using a fetcher that doesn't unpack to
           # preserve hash compatibility among case (in/)sensitive file systems.
-          all-cabal-hashes = final.fetchurl {
-            name = "all-cabal-hashes";
-            url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/5930c2335a80404908fafcff6d99ef15a3b68aae.tar.gz";
-            sha256 = "1nagkbxy9fwyx46d3cvhq1y3sanxd73hbghfyxp6mf79f21g7xci";
-          };
+          all-cabal-hashes = final.fetchurl (
+            {
+              name = "all-cabal-hashes";
+            }
+            // nixpkgs.lib.importJSON ./all-cabal-hashes.json
+          );
 
           additionalHaskellPkgSetOverrides = hfinal: hprev: {
             # Do not test libraries


### PR DESCRIPTION
Step one - this moves the data into a place where it's easier to update automatically.