### PR TITLE
Tweak SLED workflow

### DIFF
--- a/.github/workflows/sled.yml
+++ b/.github/workflows/sled.yml
@@ -39,5 +39,6 @@ jobs:
         with:
           branch: sled/auto-fix
           title: "Update Haskell dependencies"
+          commit-message: "fix(deps): update Haskell dependencies"
           base: main
           token: ${{ steps.token.outputs.token }}

--- a/.github/workflows/sled.yml
+++ b/.github/workflows/sled.yml
@@ -39,5 +39,5 @@ jobs:
         with:
           branch: sled/auto-fix
           title: "Update Haskell dependencies"
-          base: ${{ github.event.name == 'pull_request' && github.event.pull_request.head.ref || 'main' }}
+          base: main
           token: ${{ steps.token.outputs.token }}


### PR DESCRIPTION
I thought I included these in my Semantic Release PR, but I guess I forgot to push.

### [Change PR base input in SLED workflow](https://github.com/freckle/stack-lint-extra-deps/pull/88/commits/4d2ae250fd39e570fd394723feeac9fe0254b7b7)
[4d2ae25](https://github.com/freckle/stack-lint-extra-deps/pull/88/commits/4d2ae250fd39e570fd394723feeac9fe0254b7b7)

This conditional was broken, so `'main'` has always been being used. I
don't remember why I had this, but if it's working that way, we might as
well just let it be simpler.

### [Use conventional commit in SLED workflow](https://github.com/freckle/stack-lint-extra-deps/pull/88/commits/a31af625e51ff274a61fc4c733ef37099cbe080c)
[a31af62](https://github.com/freckle/stack-lint-extra-deps/pull/88/commits/a31af625e51ff274a61fc4c733ef37099cbe080c)