### PR TITLE
fix(release): go back to app token for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,12 @@ jobs:
 
       - uses: actions/download-artifact@v8
 
+      - id: token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.FRECKLE_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.FRECKLE_AUTOMATION_PRIVATE_KEY }}
+
       - id: release
         uses: cycjimmy/semantic-release-action@v6.0.0
         with:
@@ -73,4 +79,4 @@ jobs:
             @semantic-release/exec
         env:
           FORCE_COLOR: 1
-          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Bumping version requires stack, which is not present on newer macos
+      # runners
+      - run: |
+          if ! command -v stack &>/dev/null; then
+            curl -sSL https://get.haskellstack.org/ | sh
+          fi
+
       # Do a dry-run release in order to update package.yaml before compilation,
       # so the --version option works correctly.
       - uses: cycjimmy/semantic-release-action@v6.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         include:
           - os: ubuntu-latest
             suffix: x86_64-linux
-          - os: macos-13
+          - os: macos-14
             suffix: x86_64-osx
           - os: macos-latest
             suffix: arm64-osx

--- a/package.yaml
+++ b/package.yaml
@@ -4,7 +4,7 @@ name: stack-lint-extra-deps
 # {MAJOR}.{MINOR}.{PATCH} will be automatically set by semantic-release, the
 # manually-set {EPOCH} will be respected. If changing {EPOCH}, also change
 # tagFormat in .releaserc.yaml.
-version: 1.3.0.9
+version: 1.3.0.10
 extra-doc-files:
   - README.md
   - CHANGELOG.md

--- a/stack-lint-extra-deps.cabal
+++ b/stack-lint-extra-deps.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.38.1.
+-- This file has been generated from package.yaml by hpack version 0.39.1.
 --
 -- see: https://github.com/sol/hpack
 
 name:           stack-lint-extra-deps
-version:        1.3.0.9
+version:        1.3.0.10
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple


### PR DESCRIPTION
Repository automation added support for Rulesets, which means the app
bypass now works correctly.
