### PR TITLE
fix: pin conventional-changelog-conventionalcommits to avoid writer conflict

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,12 @@ jobs:
       # Do a dry-run release in order to update package.yaml before compilation,
       # so the --version option works correctly.
       - uses: cycjimmy/semantic-release-action@v6.0.0
+        # conventional-changelog-conventionalcommits is held at 9.x: v10 needs
+        # conventional-changelog-writer@9, which semantic-release@25 does not ship.
         with:
           dry_run: true
           extra_plugins: |
-            conventional-changelog-conventionalcommits
+            conventional-changelog-conventionalcommits@9
             @semantic-release/exec
         env:
           FORCE_COLOR: 1
@@ -80,9 +82,11 @@ jobs:
 
       - id: release
         uses: cycjimmy/semantic-release-action@v6.0.0
+        # conventional-changelog-conventionalcommits is held at 9.x: v10 needs
+        # conventional-changelog-writer@9, which semantic-release@25 does not ship.
         with:
           extra_plugins: |
-            conventional-changelog-conventionalcommits
+            conventional-changelog-conventionalcommits@9
             @semantic-release/exec
         env:
           FORCE_COLOR: 1


### PR DESCRIPTION
Release on `main` is failing: [run 32972822976](https://github.com/freckle/stack-lint-extra-deps/actions/runs/32972822976).

```
Error: Missing helper: "conventional-changelog-conventionalcommits requires
conventional-changelog-writer@9 or newer ..."
```

## Cause

Listed bare, the preset is not a tracked dependency — npm resolves it fresh on every workflow run. `10.0.0` published **2026-06-26** and requires `conventional-changelog-writer@9`, which the action does not supply:

```
cycjimmy/semantic-release-action@v6.0.0
  └─ semantic-release@^25
       └─ @semantic-release/release-notes-generator@^14.1.0
            └─ conventional-changelog-writer@^8.0.0
```

Nothing on our side bumps that writer — it moves when `release-notes-generator` moves.

## Why major 9, not 8

The monorepo moves preset and writer in lock-step, so the matched pair for `writer@8` is preset 9:

| preset | published | writer published same day |
|---|---|---|
| 7.0.0 | 2023-08-27 | writer 7.0.0 |
| 8.0.0 | 2024-05-03 | writer 8.0.0 |
| 9.0.0 | 2025-05-19 | writer **8.1.0** |
| 10.0.0 | 2026-06-26 | writer 9.0.0 |

Preset 9 shipped into the writer-8 line, so it is the newest major compatible with what we actually run; 8 would just be older for no benefit. Pinned major-only so 9.x fixes keep flowing.

**Evidence it works:** `@9` resolves to `9.3.1` today, and freckle/parser-js#268 has been on that since 2026-08-21 — publishing `v3.0.0`, `v3.0.1` and `v4.0.0` with fully rendered notes (compare links, `⚠ BREAKING CHANGES`, `### Features`). That markup comes from the preset via the writer, which is exactly where `Missing helper` throws, so this is the real code path exercised, not just a green exit code.

The comment sits above `with:`, not inside the `extra_plugins` block scalar where a `#` line would be read as a plugin name.

## Context

That one publish armed every freckle repo listing the preset bare; they have been tripping one at a time since, whenever each happens to cut a release. Fixed in the same pass: the repos currently failing (`maybe-js`, `aws-s3-lock-action`, `i18n-scripts-js`, `stack-lint-extra-deps`) plus the three templates that keep seeding it into new repos (`npm-package-template`, `typescript-action-template`, `haskell-cli-template`). ~13 repos still carry the bare entry but have not tripped it yet.

## Durable follow-up

The lasting half belongs in `freckle/renovate-config`, which every affected repo already extends: a `customManagers` regex entry (renovate's github-actions manager only parses `uses:` refs, so it cannot see a version inside a `with:` input) plus `allowedVersions: "<10"` — the same shape as the existing `typescript` / `!/^7\.0/` rule. Renovate cannot retrofit the repos still listing the preset bare, though: with no version string there is nothing for it to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
